### PR TITLE
[WIP] Support more `Int` combinations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ generated-docs/
 roc/
 *_example
 *.example.ll
+
+# macOS noise
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 generated-docs/
-roc/
 *_example
 *.example.ll
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "roc"]
+	path = roc
+	url = https://github.com/rtfeldman/roc

--- a/Random.roc
+++ b/Random.roc
@@ -22,25 +22,6 @@ interface Random
     imports []
 
 
-# TODO: Replace these with builtins when they're implemented
-#       (see https://github.com/rtfeldman/roc/issues/664).
-minI8 : I8
-minI8 = -128
-maxI8 : I8
-maxI8 = 127
-minI16 : I16
-minI16 = -32_768
-maxI16 : I16
-maxI16 = 32_767
-toI8 = \n -> n |> Num.toStr |> Str.toI8 |> Result.withDefault 0
-toU8 = \n -> n |> Num.toStr |> Str.toU8 |> Result.withDefault 0
-toI16 = \n -> n |> Num.toStr |> Str.toI16 |> Result.withDefault 0
-toU16 = \n -> n |> Num.toStr |> Str.toU16 |> Result.withDefault 0
-toI32 = \n -> n |> Num.toStr |> Str.toI32 |> Result.withDefault 0
-toU32 = \n -> n |> Num.toStr |> Str.toU32 |> Result.withDefault 0
-toI64 = \n -> n |> Num.toStr |> Str.toI64 |> Result.withDefault 0
-
-
 ## # Types
 
 ## A psuedorandom value generator
@@ -104,11 +85,11 @@ i8 : I8, I8 -> Generator Seed8 I8
 i8 = \x, y ->
     Pair minimum maximum = sort x y
     # TODO: Remove these `I64` dependencies.
-    range = maximum - minimum + 1 |> toI64
+    range = maximum - minimum + 1 |> Num.toI64
     \s ->
         # TODO: Analyze this. The mod-ing might be biased towards a smaller offset!
-        offset = growSeed8 s |> mapToI8 |> toI64 |> Num.sub (toI64 minI8) |> modWithNonzero range
-        value = minimum |> toI64 |> Num.add offset |> toI8
+        offset = growSeed8 s |> Num.toI8 |> Num.toI64 |> Num.sub (Num.toI64 Num.minI8) |> modWithNonzero range
+        value = minimum |> Num.toI64 |> Num.add offset |> Num.toI8
         { value, seed: updateSeed8 s }
 
 ## A [Generator] for 16-bit signed integers between two boundaries (inclusive)
@@ -116,11 +97,11 @@ i16 : I16, I16 -> Generator Seed16 I16
 i16 = \x, y ->
     Pair minimum maximum = sort x y
     # TODO: Remove these `I64` dependencies.
-    range = maximum - minimum + 1 |> toI64
+    range = maximum - minimum + 1 |> Num.toI64
     \s ->
         # TODO: Analyze this. The mod-ing might be biased towards a smaller offset!
-        offset = growSeed16 s |> mapToI16 |> toI64 |> Num.sub (toI64 minI16) |> modWithNonzero range
-        value = minimum |> toI64 |> Num.add offset |> toI16
+        offset = growSeed16 s |> Num.toI16 |> Num.toI64 |> Num.sub (Num.toI64 Num.minI16) |> modWithNonzero range
+        value = minimum |> Num.toI64 |> Num.add offset |> Num.toI16
         { value, seed: updateSeed16 s }
 
 ## A [Generator] for 32-bit signed integers between two boundaries (inclusive)
@@ -128,11 +109,11 @@ i32 : I32, I32 -> Generator Seed32 I32
 i32 = \x, y ->
     Pair minimum maximum = sort x y
     # TODO: Remove these `I64` dependencies.
-    range = maximum - minimum + 1 |> toI64
+    range = maximum - minimum + 1 |> Num.toI64
     \s ->
         # TODO: Analyze this. The mod-ing might be biased towards a smaller offset!
-        offset = growSeed32 s |> mapToI32 |> toI64 |> Num.sub (toI64 Num.minI32) |> modWithNonzero range
-        value = minimum |> toI64 |> Num.add offset |> toI32
+        offset = growSeed32 s |> Num.toI32 |> Num.toI64 |> Num.sub (Num.toI64 Num.Num.minI32) |> modWithNonzero range
+        value = minimum |> Num.toI64 |> Num.add offset |> Num.toI32
         { value, seed: updateSeed32 s }
 
 ## A [Generator] for 8-bit unsigned integers between two boundaries (inclusive)
@@ -160,30 +141,6 @@ betweenUnsigned = \x, y, growSeed, updateSeed ->
         # TODO: Analyze this. The mod-ing might be biased towards a smaller offset!
         value = minimum + modWithNonzero (growSeed s) range
         { value, seed: updateSeed s }
-
-mapToI8 : U8 -> I8
-mapToI8 = \x ->
-    middle = toU8 maxI8
-    if x <= middle then
-        minI8 + toI8 x
-    else
-        toI8 (x - middle - 1)
-
-mapToI16 : U16 -> I16
-mapToI16 = \x ->
-    middle = toU16 maxI16
-    if x <= middle then
-        minI16 + toI16 x
-    else
-        toI16 (x - middle - 1)
-
-mapToI32 : U32 -> I32
-mapToI32 = \x ->
-    middle = toU32 Num.maxI32
-    if x <= middle then
-        Num.minI32 + toI32 x
-    else
-        toI32 (x - middle - 1)
 
 # Warning: y must never equal 0. The `123` fallback is nonsense for typechecking only.
 modWithNonzero = \x, y -> x % y |> Result.withDefault 123
@@ -244,7 +201,7 @@ growSeed32 = \Seed32 state ->
     xs = 22
     pcgRxsMXs state rxs rxsi m xs
 
-# TODO: This is waiting on literals > maxI64 (https://github.com/rtfeldman/roc/issues/2332).
+# TODO: This is waiting on literals > Num.maxI64 (https://github.com/rtfeldman/roc/issues/2332).
 # # See `pcg_output_rxs_m_xs_64_64` (on line 188?) in the C++ header.
 # growSeed64 = Seed64 -> U64
 # growSeed64 = \Seed64 state ->
@@ -258,7 +215,7 @@ growSeed32 = \Seed32 state ->
 #     xs = 43
 #     pcgRxsMXs state rxs rxsi m xs
 
-# TODO: This is waiting on literals > maxI64 (https://github.com/rtfeldman/roc/issues/2332).
+# TODO: This is waiting on literals > Num.maxI64 (https://github.com/rtfeldman/roc/issues/2332).
 # # See `pcg_output_rxs_m_xs_128_128` (on line 196?) in the C++ header.
 # growSeed128 = Seed128 -> U128
 # growSeed128 = \Seed128 state ->


### PR DESCRIPTION
Now that https://github.com/rtfeldman/roc/pull/2472 is merged, this library can support downsizing/shifting outputs to `Int` types with smaller/similar size.