### PR TITLE
Refactor to use vertical bars for function defs

### DIFF
--- a/examples/color.roc
+++ b/examples/color.roc
@@ -19,6 +19,6 @@ color_generator =
 
 seed = Random.seed(12345)
 
-main! = \_ ->
+main! = |_|
     { value: color } = Random.step(seed, color_generator)
-    Stdout.line!("Color generated: $(Inspect.to_str(color))")
+    Stdout.line!("Color generated: ${Inspect.to_str(color)}")

--- a/examples/numbers.roc
+++ b/examples/numbers.roc
@@ -7,11 +7,11 @@ import cli.Stdout
 import rand.Random
 
 # Print a list of 10 random numbers in the range 25-75 inclusive.
-main! = \_ ->
+main! = |_|
     random_numbers
     |> List.map(Num.to_str)
     |> Str.join_with("\n")
-    |> \numbers_list_str -> Stdout.line!("$(numbers_list_str)")
+    |> |numbers_list_str| Stdout.line!("${numbers_list_str}")
 
 numbers_generator : Random.Generator (List U32)
 numbers_generator =

--- a/examples/simple.roc
+++ b/examples/simple.roc
@@ -12,9 +12,9 @@ seed = Random.seed(1234)
 # Generate a random number in the range 25-75 inclusive and convert it to a Str
 generator = Random.bounded_u32(25, 75) |> Random.map(Num.to_str)
 
-main! = \_ ->
+main! = |_|
     { value } = Random.step(seed, generator)
 
-    Stdout.line!("Random number is $(value)")
+    Stdout.line!("Random number is ${value}")
 
 expect Random.step(seed, generator) |> .value == "52"


### PR DESCRIPTION
Since it's easiest to create this via `roc format --migrate`, this is circumstantially blocked by #30.