### PR TITLE
Bump Nix dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1736143030,
-        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
+        "lastModified": 1738453229,
+        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
+        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737469691,
-        "narHash": "sha256-nmKOgAU48S41dTPIXAq0AHZSehWUn6ZPrUKijHAMmIk=",
+        "lastModified": 1739214665,
+        "narHash": "sha256-26L8VAu3/1YRxS8MHgBOyOM8xALdo6N0I04PgorE7UM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab",
+        "rev": "64e75cd44acf21c7933d61d7721e812eac1b5a0a",
         "type": "github"
       },
       "original": {
@@ -95,14 +95,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1735774519,
-        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
+        "lastModified": 1738452942,
+        "narHash": "sha256-vJzFZGaCpnmo7I6i416HaBLpC+hvcURh/BQwROcGIp8=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       }
     },
     "nixpkgs_2": {


### PR DESCRIPTION
Inspired by [this PR](https://github.com/lukewilliamboswell/roc-random/pull/14), I ran `nix flake update`. @Anton-4 Does this look right?

I said yes to some questions:

```
jan@framey:~/_code/JanCVanB/roc-random$ nix flake update
do you want to allow configuration setting 'extra-trusted-public-keys' to be set to 'roc-lang.cachix.org-1:6lZeqLP9SadjmUbskJAvcdGR2T5ViR57pDVkxJQb8R4=' (
y/N)? Y
do you want to permanently mark this value as trusted (y/N)? Y
do you want to allow configuration setting 'extra-trusted-substituters' to be set to 'https://roc-lang.cachix.org' (y/N)? Y
do you want to permanently mark this value as trusted (y/N)? Y
warning: ignoring the client-specified setting 'trusted-public-keys', because it is a restricted setting and you are not a trusted user
warning: ignoring the client-specified setting 'trusted-substituters', because it is a restricted setting and you are not a trusted user
warning: updating lock file '/home/jan/_code/JanCVanB/roc-random/flake.lock':
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/b905f6fc23a9051a6e1b741e1438dbfc0634c6de?narHash=sha256-%2Bhu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU%3D' (2025-01-06)
  → 'github:hercules-ci/flake-parts/32ea77a06711b758da0ad9bd6a844c5740a87abd?narHash=sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm%2BzmZ7vxbJdo%3D' (2025-02-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz?narHash=sha256-CewEm1o2eVAnoqb6Ml%2BQi9Gg/EfNAxbRx1lANGVyoLI
%3D' (2025-01-01)
  → 'https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz?narHash=sha256-vJzFZGaCpnmo7I6i416HaBLpC%2BhvcURh/BQwROcGIp8
%3D' (2025-02-01)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab?narHash=sha256-nmKOgAU48S41dTPIXAq0AHZSehWUn6ZPrUKijHAMmIk%3D' (2025-01-21)
  → 'github:nixos/nixpkgs/64e75cd44acf21c7933d61d7721e812eac1b5a0a?narHash=sha256-26L8VAu3/1YRxS8MHgBOyOM8xALdo6N0I04PgorE7UM%3D' (2025-02-10)
• Updated input 'roc':
    'github:roc-lang/roc/36aa6f0883dcae55283991d6a65fcd81da0fa87c?narHash=sha256-cHnBuIH2M3/IzxVim78kMSWoKUkKJvEyVI4VcoWxKrA%3D' (2025-01-23)
  → 'github:roc-lang/roc/040453bb0c88871998e49587c1b00fa7691c214f?narHash=sha256-kDLrgGbF6bme2bQq4W15gXr9Jj5we0ymnHyE%2B82WmVo%3D' (2025-02-13)
• Removed input 'roc/nixgl'
• Removed input 'roc/nixgl/flake-utils'
• Removed input 'roc/nixgl/nixpkgs'
warning: Git tree '/home/jan/_code/JanCVanB/roc-random' is dirty
jan@framey:~/_code/JanCVanB/roc-random$
```