### PR TITLE
Point examples at 0.6.0 release bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Stdout.line!(Str.join_with(numbers.map(U32.to_str), "\n"))
 
 ## Documentation
 
-See [the library documentation site](https://jancvanb.github.io/roc-random/0.5.0/Random/)
+See [the library documentation site](https://kili-ilo.github.io/roc-random/0.6.0/)
 for more info about its API.
 
 ## Goals

--- a/docs.sh
+++ b/docs.sh
@@ -23,11 +23,6 @@ VERSION=$1
 # Validate version number
 validate_version "$VERSION"
 
-# Run roc docs with validated version
-roc docs --root-dir "/roc-random/$VERSION/" package/main.roc
-
-# Create new version directory in www/
-mkdir www/$VERSION
-
-# Move generated docs to version directory
-mv generated-docs/* www/$VERSION
+# Generate docs for this version into www/
+rm -rf "www/$VERSION"
+roc docs package/main.roc --output="www/$VERSION"

--- a/examples/color.roc
+++ b/examples/color.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-	rand: "../package/main.roc",
+	rand: "https://github.com/kili-ilo/roc-random/releases/download/0.6.0/4mHqd7aiQ1hYkoso9C8JRfnx3GuwcwoDqv8EdqAsLbfN.tar.zst",
 }
 
 import pf.Stdout

--- a/examples/dice.roc
+++ b/examples/dice.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-	rand: "../package/main.roc",
+	rand: "https://github.com/kili-ilo/roc-random/releases/download/0.6.0/4mHqd7aiQ1hYkoso9C8JRfnx3GuwcwoDqv8EdqAsLbfN.tar.zst",
 }
 
 import pf.Stdout

--- a/examples/encounter.roc
+++ b/examples/encounter.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-	rand: "../package/main.roc",
+	rand: "https://github.com/kili-ilo/roc-random/releases/download/0.6.0/4mHqd7aiQ1hYkoso9C8JRfnx3GuwcwoDqv8EdqAsLbfN.tar.zst",
 }
 
 import pf.Stdout

--- a/examples/numbers.roc
+++ b/examples/numbers.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-	rand: "../package/main.roc",
+	rand: "https://github.com/kili-ilo/roc-random/releases/download/0.6.0/4mHqd7aiQ1hYkoso9C8JRfnx3GuwcwoDqv8EdqAsLbfN.tar.zst",
 }
 
 import pf.Stdout

--- a/examples/record-builder.roc
+++ b/examples/record-builder.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-	rand: "../package/main.roc",
+	rand: "https://github.com/kili-ilo/roc-random/releases/download/0.6.0/4mHqd7aiQ1hYkoso9C8JRfnx3GuwcwoDqv8EdqAsLbfN.tar.zst",
 }
 
 import pf.Stdout

--- a/examples/simple.roc
+++ b/examples/simple.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-	rand: "../package/main.roc",
+	rand: "https://github.com/kili-ilo/roc-random/releases/download/0.6.0/4mHqd7aiQ1hYkoso9C8JRfnx3GuwcwoDqv8EdqAsLbfN.tar.zst",
 }
 
 import pf.Stdout

--- a/examples/state-threading.roc
+++ b/examples/state-threading.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-	rand: "../package/main.roc",
+	rand: "https://github.com/kili-ilo/roc-random/releases/download/0.6.0/4mHqd7aiQ1hYkoso9C8JRfnx3GuwcwoDqv8EdqAsLbfN.tar.zst",
 }
 
 import pf.Stdout

--- a/examples/variants.roc
+++ b/examples/variants.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-	rand: "../package/main.roc",
+	rand: "https://github.com/kili-ilo/roc-random/releases/download/0.6.0/4mHqd7aiQ1hYkoso9C8JRfnx3GuwcwoDqv8EdqAsLbfN.tar.zst",
 }
 
 import pf.Stdout

--- a/www/0.6.0/favicon.svg
+++ b/www/0.6.0/favicon.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 52 53" xmlns="http://www.w3.org/2000/svg">
+  <!-- Make this icon look nicer in dark mode. (Only Firefox supports this; others ignore it.) -->
+  <style>@media (prefers-color-scheme: dark){polygon{fill:#9c7bea}}</style>
+  <polygon fill="#7d59dd" points="0,0 23.8834,3.21052 37.2438,19.0101 45.9665,16.6324 50.5,22 45,22 44.0315,26.3689 26.4673,39.3424 27.4527,45.2132 17.655,53 23.6751,22.7086"/>
+</svg>

--- a/www/0.6.0/index.html
+++ b/www/0.6.0/index.html
@@ -1,0 +1,352 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Random Docs</title>
+    <meta name="viewport" content="width=device-width">
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+    <link rel="stylesheet" href="styles.css">
+    <script src="search.js" defer></script>
+</head>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <symbol id="link-icon" viewBox="0 0 640 512">
+      <path d="M562.8 267.7c56.5-56.5 56.5-148 0-204.5c-50-50-128.8-56.5-186.3-15.4l-1.6 1.1c-14.4 10.3-17.7 30.3-7.4 44.6s30.3 17.7 44.6 7.4l1.6-1.1c32.1-22.9 76-19.3 103.8 8.6c31.5 31.5 31.5 82.5 0 114L405.3 334.8c-31.5 31.5-82.5 31.5-114 0c-27.9-27.9-31.5-71.8-8.6-103.8l1.1-1.6c10.3-14.4 6.9-34.4-7.4-44.6s-34.4-6.9-44.6 7.4l-1.1 1.6C189.5 251.2 196 330 246 380c56.5 56.5 148 56.5 204.5 0L562.8 267.7zM43.2 244.3c-56.5 56.5-56.5 148 0 204.5c50 50 128.8 56.5 186.3 15.4l1.6-1.1c14.4-10.3 17.7-30.3 7.4-44.6s-30.3-17.7-44.6-7.4l-1.6 1.1c-32.1 22.9-76 19.3-103.8-8.6C57 372 57 321 88.5 289.5L200.7 177.2c31.5-31.5 82.5-31.5 114 0c27.9 27.9 31.5 71.8 8.6 103.9l-1.1 1.6c-10.3 14.4-6.9 34.4 7.4 44.6s34.4 6.9 44.6-7.4l1.1-1.6C416.5 260.8 410 182 360 132c-56.5-56.5-148-56.5-204.5 0L43.2 244.3z"/>
+    </symbol>
+  </defs>
+</svg>
+    <nav id="sidebar-nav">
+        <div class="pkg-and-logo">
+            <a class="logo" href="."><svg viewBox="0 -6 51 58" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="logo-link">
+    <title id="logo-link">Home</title>
+    <polygon role="presentation" points="0,0 23.8834,3.21052 37.2438,19.0101 45.9665,16.6324 50.5,22 45,22 44.0315,26.3689 26.4673,39.3424 27.4527,45.2132 17.655,53 23.6751,22.7086" />
+</svg></a>
+            <h1 class="pkg-full-name"><a href="">package</a></h1>
+        </div>
+        <div class="module-links-container">
+            <ul class="module-links">
+                <li class="sidebar-entry">
+                    <a class="sidebar-module-link active" data-module-name="Random" href="."><button class="entry-toggle"></button><span>Random</span></a>
+                    <ul class="sidebar-sub-entries">
+                        <li><a class="sidebar-value" href="#Random.seed">seed</a></li>
+                        <li><a class="sidebar-value" href="#Random.seed_variant">seed_variant</a></li>
+                        <li><a class="sidebar-value" href="#Random.step">step</a></li>
+                        <li><a class="sidebar-value" href="#Random.next">next</a></li>
+                        <li><a class="sidebar-value" href="#Random.static">static</a></li>
+                        <li><a class="sidebar-value" href="#Random.map">map</a></li>
+                        <li><a class="sidebar-value" href="#Random.map2">map2</a></li>
+                        <li><a class="sidebar-value" href="#Random.chain">chain</a></li>
+                        <li><a class="sidebar-value" href="#Random.list">list</a></li>
+                        <li><a class="sidebar-value" href="#Random.u8">u8</a></li>
+                        <li><a class="sidebar-value" href="#Random.bounded_u8">bounded_u8</a></li>
+                        <li><a class="sidebar-value" href="#Random.i8">i8</a></li>
+                        <li><a class="sidebar-value" href="#Random.bounded_i8">bounded_i8</a></li>
+                        <li><a class="sidebar-value" href="#Random.u16">u16</a></li>
+                        <li><a class="sidebar-value" href="#Random.bounded_u16">bounded_u16</a></li>
+                        <li><a class="sidebar-value" href="#Random.i16">i16</a></li>
+                        <li><a class="sidebar-value" href="#Random.bounded_i16">bounded_i16</a></li>
+                        <li><a class="sidebar-value" href="#Random.u32">u32</a></li>
+                        <li><a class="sidebar-value" href="#Random.bounded_u32">bounded_u32</a></li>
+                        <li><a class="sidebar-value" href="#Random.i32">i32</a></li>
+                        <li><a class="sidebar-value" href="#Random.bounded_i32">bounded_i32</a></li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="#Random.Generator">Generator</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="#Random.Generation">Generation</a>
+                        </li>
+                        <li class="sidebar-type">
+                          <a class="sidebar-type-name" href="#Random.State">State</a>
+                        </li>
+                    </ul>
+                </li>
+            </ul>
+        </div>
+    </nav>
+    <main>
+        <form id="module-search-form">
+            <input type="search" id="module-search" placeholder="Search Documentation" autocomplete="off" />
+            <input type="search" id="module-search-nojs" placeholder="Enable JavaScript to search" autocomplete="off" disabled aria-label="Search requires JavaScript" />
+            <noscript><style>#module-search{display:none}#module-search-nojs{display:block}</style></noscript>
+            <button class="menu-toggle" type="button" aria-label="Toggle sidebar"><svg viewBox="0 6 18 12" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 6h18v2H0V6zm0 5h18v2H0v-2zm0 5h18v2H0v-2z"/>
+</svg></button>
+            <ul id="search-type-ahead" class="hidden">
+            <li class="hidden"><a class="type-ahead-link" href="#Random.seed"><span class="type-ahead-def-name">seed</span> <span class="type-ahead-signature">: <span class="type">U32</span><span class="sig-arrow"> -&gt; </span><span class="type">State</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.seed_variant"><span class="type-ahead-def-name">seed_variant</span> <span class="type-ahead-signature">: <span class="type">U32</span>, <span class="type">U32</span><span class="sig-arrow"> -&gt; </span><span class="type">State</span></span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.step"><span class="type-ahead-def-name">step</span> <span class="type-ahead-signature">: <span class="type">State</span>, <span class="type">Generator</span>(<span class="type-var">value</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Generation</span>(<span class="type-var">value</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.next"><span class="type-ahead-def-name">next</span> <span class="type-ahead-signature">: <span class="type">Generation</span>(_), <span class="type">Generator</span>(<span class="type-var">value</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Generation</span>(<span class="type-var">value</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.static"><span class="type-ahead-def-name">static</span> <span class="type-ahead-signature">: <span class="type-var">value</span><span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<span class="type-var">value</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.map"><span class="type-ahead-def-name">map</span> <span class="type-ahead-signature">: <span class="type">Generator</span>(<span class="type-var">a</span>), (<span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<span class="type-var">b</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.map2"><span class="type-ahead-def-name">map2</span> <span class="type-ahead-signature">: <span class="type">Generator</span>(<span class="type-var">a</span>), <span class="type">Generator</span>(<span class="type-var">b</span>), (<span class="type-var">a</span>, <span class="type-var">b</span><span class="sig-arrow"> -&gt; </span><span class="type-var">c</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<span class="type-var">c</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.chain"><span class="type-ahead-def-name">chain</span> <span class="type-ahead-signature">: <span class="type">Generator</span>(<span class="type-var">a</span>), <span class="type">Generator</span>(<span class="type-var">b</span>), (<span class="type-var">a</span>, <span class="type-var">b</span><span class="sig-arrow"> -&gt; </span><span class="type-var">c</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<span class="type-var">c</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.list"><span class="type-ahead-def-name">list</span> <span class="type-ahead-signature">: <span class="type">Generator</span>(<span class="type-var">a</span>), <span class="type">U64</span><span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<span class="type">List</span>(<span class="type-var">a</span>))</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.u8"><span class="type-ahead-def-name">u8</span> <span class="type-ahead-signature">: <span class="type">Generator</span>(<span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.bounded_u8"><span class="type-ahead-def-name">bounded_u8</span> <span class="type-ahead-signature">: <span class="type">U8</span>, <span class="type">U8</span><span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<span class="type">U8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.i8"><span class="type-ahead-def-name">i8</span> <span class="type-ahead-signature">: <span class="type">Generator</span>(<span class="type">I8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.bounded_i8"><span class="type-ahead-def-name">bounded_i8</span> <span class="type-ahead-signature">: <span class="type">I8</span>, <span class="type">I8</span><span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<span class="type">I8</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.u16"><span class="type-ahead-def-name">u16</span> <span class="type-ahead-signature">: <span class="type">Generator</span>(<span class="type">U16</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.bounded_u16"><span class="type-ahead-def-name">bounded_u16</span> <span class="type-ahead-signature">: <span class="type">U16</span>, <span class="type">U16</span><span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<span class="type">U16</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.i16"><span class="type-ahead-def-name">i16</span> <span class="type-ahead-signature">: <span class="type">Generator</span>(<span class="type">I16</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.bounded_i16"><span class="type-ahead-def-name">bounded_i16</span> <span class="type-ahead-signature">: <span class="type">I16</span>, <span class="type">I16</span><span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<span class="type">I16</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.u32"><span class="type-ahead-def-name">u32</span> <span class="type-ahead-signature">: <span class="type">Generator</span>(<span class="type">U32</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.bounded_u32"><span class="type-ahead-def-name">bounded_u32</span> <span class="type-ahead-signature">: <span class="type">U32</span>, <span class="type">U32</span><span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<span class="type">U32</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.i32"><span class="type-ahead-def-name">i32</span> <span class="type-ahead-signature">: <span class="type">Generator</span>(<span class="type">I32</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.bounded_i32"><span class="type-ahead-def-name">bounded_i32</span> <span class="type-ahead-signature">: <span class="type">I32</span>, <span class="type">I32</span><span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<span class="type">I32</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.Generator"><span class="type-ahead-def-name">Generator</span> <span class="type-ahead-signature">: <span class="type">State</span><span class="sig-arrow"> -&gt; </span><span class="type">Generation</span>(<span class="type-var">value</span>)</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.Generation"><span class="type-ahead-def-name">Generation</span> <span class="type-ahead-signature">: { value : <span class="type-var">value</span>, state : <span class="type">State</span> }</span></a></li>
+            <li class="hidden"><a class="type-ahead-link" href="#Random.State"><span class="type-ahead-def-name">State</span> <span class="type-ahead-signature"></span></a></li>
+            </ul>
+        </form>
+        <div class="main-content">
+        <h1 class="module-name">Random</h1>
+        <code class="entry-type-def">:= []</code>
+        <div class="module-doc">
+                <p>PCG algorithms, constants, and wrappers</p>
+                <p>For more information about PCG see <a href="https://www.pcg-random.org">www.pcg-random.org</a></p>
+                <p>PCG is a family of simple fast space-efficient statistically good algorithms for random number generation.</p>
+        </div>
+        <article class="entry entry-value" id="Random.seed">
+            <div class="entry-signature">
+                <a href="#Random.seed" class="entry-anchor" aria-label="Permalink to seed"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.seed" class="entry-name-link"><strong>seed</strong></a> : <a href="https://roc-lang.org/builtins/main/Num#U32"><span class="type">U32</span></a><span class="sig-arrow"> -&gt; </span><span class="type">State</span></code>
+            </div>
+            <div class="entry-doc">
+                <p>Construct an initial &quot;seed&quot; <code>State</code> for <code>Generator</code>s</p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Random.seed_variant">
+            <div class="entry-signature">
+                <a href="#Random.seed_variant" class="entry-anchor" aria-label="Permalink to seed_variant"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.seed_variant" class="entry-name-link"><strong>seed_variant</strong></a> : <a href="https://roc-lang.org/builtins/main/Num#U32"><span class="type">U32</span></a>, <a href="https://roc-lang.org/builtins/main/Num#U32"><span class="type">U32</span></a><span class="sig-arrow"> -&gt; </span><span class="type">State</span></code>
+            </div>
+            <div class="entry-doc">
+                <p>Construct a specific &quot;variant&quot; of a &quot;seed&quot; for more advanced use.</p>
+                <p>A &quot;seed&quot; is an initial <code>State</code> for <code>Generator</code>s.</p>
+                <p>A &quot;variant&quot; is a <code>State</code> that specifies an <code>update_increment</code> constant,
+to produce a sequence of internal <code>value</code>s that shares no consecutive pairs
+with other variants of the same <code>State</code>.</p>
+                <p>Odd numbers are recommended for the update increment,
+to double the repetition period of sequences (by hitting odd values).</p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Random.step">
+            <div class="entry-signature">
+                <a href="#Random.step" class="entry-anchor" aria-label="Permalink to step"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.step" class="entry-name-link"><strong>step</strong></a> : <span class="type">State</span>, <span class="type">Generator</span>(<span class="type-var">value</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Generation</span>(<span class="type-var">value</span>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Generate a <code>Generation</code> from a state</p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Random.next">
+            <div class="entry-signature">
+                <a href="#Random.next" class="entry-anchor" aria-label="Permalink to next"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.next" class="entry-name-link"><strong>next</strong></a> : <span class="type">Generation</span>(_), <span class="type">Generator</span>(<span class="type-var">value</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Generation</span>(<span class="type-var">value</span>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Generate a new <code>Generation</code> from an old <code>Generation</code>&#39;s state</p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Random.static">
+            <div class="entry-signature">
+                <a href="#Random.static" class="entry-anchor" aria-label="Permalink to static"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.static" class="entry-name-link"><strong>static</strong></a> : <span class="type-var">value</span><span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<span class="type-var">value</span>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Create a <code>Generator</code> that always returns the same thing.</p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Random.map">
+            <div class="entry-signature">
+                <a href="#Random.map" class="entry-anchor" aria-label="Permalink to map"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.map" class="entry-name-link"><strong>map</strong></a> : <span class="type">Generator</span>(<span class="type-var">a</span>), (<span class="type-var">a</span><span class="sig-arrow"> -&gt; </span><span class="type-var">b</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<span class="type-var">b</span>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Map over the value of a <code>Generator</code>.</p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Random.map2">
+            <div class="entry-signature">
+                <a href="#Random.map2" class="entry-anchor" aria-label="Permalink to map2"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.map2" class="entry-name-link"><strong>map2</strong></a> : <span class="type">Generator</span>(<span class="type-var">a</span>), <span class="type">Generator</span>(<span class="type-var">b</span>), (<span class="type-var">a</span>, <span class="type-var">b</span><span class="sig-arrow"> -&gt; </span><span class="type-var">c</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<span class="type-var">c</span>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Compose two <code>Generator</code>s into a single <code>Generator</code>.</p>
+                <p>This is the applicative operation used by Roc&#39;s record-builder syntax:</p>
+                <pre><code>date_generator =
+    {
+        year: Random.bounded_i32(1, 2500),
+        month: Random.bounded_i32(1, 12),
+        day: Random.bounded_i32(1, 31),
+    }.Random</code></pre>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Random.chain">
+            <div class="entry-signature">
+                <a href="#Random.chain" class="entry-anchor" aria-label="Permalink to chain"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.chain" class="entry-name-link"><strong>chain</strong></a> : <span class="type">Generator</span>(<span class="type-var">a</span>), <span class="type">Generator</span>(<span class="type-var">b</span>), (<span class="type-var">a</span>, <span class="type-var">b</span><span class="sig-arrow"> -&gt; </span><span class="type-var">c</span>)<span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<span class="type-var">c</span>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Compose two <code>Generator</code>s into a single <code>Generator</code>.</p>
+                <p>This is an alias for <code>map2</code>; record-builder syntax calls <code>map2</code> directly.</p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Random.list">
+            <div class="entry-signature">
+                <a href="#Random.list" class="entry-anchor" aria-label="Permalink to list"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.list" class="entry-name-link"><strong>list</strong></a> : <span class="type">Generator</span>(<span class="type-var">a</span>), <a href="https://roc-lang.org/builtins/main/Num#U64"><span class="type">U64</span></a><span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<a href="https://roc-lang.org/builtins/main/List"><span class="type">List</span></a>(<span class="type-var">a</span>))</code>
+            </div>
+            <div class="entry-doc">
+                <p>Generate a list of random values.</p>
+                <pre><code>generate_10_random_u8s : Generator(List(U8))
+generate_10_random_u8s =
+    Random.list(Random.u8, 10)</code></pre>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Random.u8">
+            <div class="entry-signature">
+                <a href="#Random.u8" class="entry-anchor" aria-label="Permalink to u8"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.u8" class="entry-name-link"><strong>u8</strong></a> : <span class="type">Generator</span>(<a href="https://roc-lang.org/builtins/main/Num#U8"><span class="type">U8</span></a>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Construct a <code>Generator</code> for 8-bit unsigned integers</p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Random.bounded_u8">
+            <div class="entry-signature">
+                <a href="#Random.bounded_u8" class="entry-anchor" aria-label="Permalink to bounded_u8"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.bounded_u8" class="entry-name-link"><strong>bounded_u8</strong></a> : <a href="https://roc-lang.org/builtins/main/Num#U8"><span class="type">U8</span></a>, <a href="https://roc-lang.org/builtins/main/Num#U8"><span class="type">U8</span></a><span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<a href="https://roc-lang.org/builtins/main/Num#U8"><span class="type">U8</span></a>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Construct a <code>Generator</code> for 8-bit unsigned integers between two boundaries (inclusive)</p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Random.i8">
+            <div class="entry-signature">
+                <a href="#Random.i8" class="entry-anchor" aria-label="Permalink to i8"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.i8" class="entry-name-link"><strong>i8</strong></a> : <span class="type">Generator</span>(<a href="https://roc-lang.org/builtins/main/Num#I8"><span class="type">I8</span></a>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Construct a <code>Generator</code> for 8-bit signed integers</p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Random.bounded_i8">
+            <div class="entry-signature">
+                <a href="#Random.bounded_i8" class="entry-anchor" aria-label="Permalink to bounded_i8"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.bounded_i8" class="entry-name-link"><strong>bounded_i8</strong></a> : <a href="https://roc-lang.org/builtins/main/Num#I8"><span class="type">I8</span></a>, <a href="https://roc-lang.org/builtins/main/Num#I8"><span class="type">I8</span></a><span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<a href="https://roc-lang.org/builtins/main/Num#I8"><span class="type">I8</span></a>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Construct a <code>Generator</code> for 8-bit signed integers between two boundaries (inclusive)</p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Random.u16">
+            <div class="entry-signature">
+                <a href="#Random.u16" class="entry-anchor" aria-label="Permalink to u16"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.u16" class="entry-name-link"><strong>u16</strong></a> : <span class="type">Generator</span>(<a href="https://roc-lang.org/builtins/main/Num#U16"><span class="type">U16</span></a>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Construct a <code>Generator</code> for 16-bit unsigned integers</p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Random.bounded_u16">
+            <div class="entry-signature">
+                <a href="#Random.bounded_u16" class="entry-anchor" aria-label="Permalink to bounded_u16"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.bounded_u16" class="entry-name-link"><strong>bounded_u16</strong></a> : <a href="https://roc-lang.org/builtins/main/Num#U16"><span class="type">U16</span></a>, <a href="https://roc-lang.org/builtins/main/Num#U16"><span class="type">U16</span></a><span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<a href="https://roc-lang.org/builtins/main/Num#U16"><span class="type">U16</span></a>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Construct a <code>Generator</code> for 16-bit unsigned integers between two boundaries (inclusive)</p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Random.i16">
+            <div class="entry-signature">
+                <a href="#Random.i16" class="entry-anchor" aria-label="Permalink to i16"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.i16" class="entry-name-link"><strong>i16</strong></a> : <span class="type">Generator</span>(<a href="https://roc-lang.org/builtins/main/Num#I16"><span class="type">I16</span></a>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Construct a <code>Generator</code> for 16-bit signed integers</p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Random.bounded_i16">
+            <div class="entry-signature">
+                <a href="#Random.bounded_i16" class="entry-anchor" aria-label="Permalink to bounded_i16"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.bounded_i16" class="entry-name-link"><strong>bounded_i16</strong></a> : <a href="https://roc-lang.org/builtins/main/Num#I16"><span class="type">I16</span></a>, <a href="https://roc-lang.org/builtins/main/Num#I16"><span class="type">I16</span></a><span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<a href="https://roc-lang.org/builtins/main/Num#I16"><span class="type">I16</span></a>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Construct a <code>Generator</code> for 16-bit signed integers between two boundaries (inclusive)</p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Random.u32">
+            <div class="entry-signature">
+                <a href="#Random.u32" class="entry-anchor" aria-label="Permalink to u32"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.u32" class="entry-name-link"><strong>u32</strong></a> : <span class="type">Generator</span>(<a href="https://roc-lang.org/builtins/main/Num#U32"><span class="type">U32</span></a>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Construct a <code>Generator</code> for 32-bit unsigned integers</p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Random.bounded_u32">
+            <div class="entry-signature">
+                <a href="#Random.bounded_u32" class="entry-anchor" aria-label="Permalink to bounded_u32"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.bounded_u32" class="entry-name-link"><strong>bounded_u32</strong></a> : <a href="https://roc-lang.org/builtins/main/Num#U32"><span class="type">U32</span></a>, <a href="https://roc-lang.org/builtins/main/Num#U32"><span class="type">U32</span></a><span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<a href="https://roc-lang.org/builtins/main/Num#U32"><span class="type">U32</span></a>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Construct a <code>Generator</code> for 32-bit unsigned integers between two boundaries (inclusive)</p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Random.i32">
+            <div class="entry-signature">
+                <a href="#Random.i32" class="entry-anchor" aria-label="Permalink to i32"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.i32" class="entry-name-link"><strong>i32</strong></a> : <span class="type">Generator</span>(<a href="https://roc-lang.org/builtins/main/Num#I32"><span class="type">I32</span></a>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Construct a <code>Generator</code> for 32-bit signed integers</p>
+            </div>
+        </article>
+        <article class="entry entry-value" id="Random.bounded_i32">
+            <div class="entry-signature">
+                <a href="#Random.bounded_i32" class="entry-anchor" aria-label="Permalink to bounded_i32"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.bounded_i32" class="entry-name-link"><strong>bounded_i32</strong></a> : <a href="https://roc-lang.org/builtins/main/Num#I32"><span class="type">I32</span></a>, <a href="https://roc-lang.org/builtins/main/Num#I32"><span class="type">I32</span></a><span class="sig-arrow"> -&gt; </span><span class="type">Generator</span>(<a href="https://roc-lang.org/builtins/main/Num#I32"><span class="type">I32</span></a>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>Construct a <code>Generator</code> for 32-bit signed integers between two boundaries (inclusive)</p>
+            </div>
+        </article>
+        <article class="entry entry-type" id="Random.Generator">
+            <div class="entry-signature">
+                <a href="#Random.Generator" class="entry-anchor" aria-label="Permalink to Generator"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.Generator" class="entry-name-link"><strong>Generator</strong></a> : <span class="type">State</span><span class="sig-arrow"> -&gt; </span><span class="type">Generation</span>(<span class="type-var">value</span>)</code>
+            </div>
+            <div class="entry-doc">
+                <p>A generator that produces pseudorandom <code>value</code>s using the PCG algorithm.</p>
+                <pre><code>rgb_generator : Generator({ red: U8, green: U8, blue: U8 })
+rgb_generator =
+    {
+        red: Random.u8,
+        green: Random.u8,
+        blue: Random.u8,
+    }.Random</code></pre>
+            </div>
+        </article>
+        <article class="entry entry-type" id="Random.Generation">
+            <div class="entry-signature">
+                <a href="#Random.Generation" class="entry-anchor" aria-label="Permalink to Generation"><svg class="link-icon"><use href="#link-icon"/></svg></a>
+                <code class="entry-signature-code"><a href="#Random.Generation" class="entry-name-link"><strong>Generation</strong></a> : { value : <span class="type-var">value</span>, state : <span class="type">State</span> }</code>
+            </div>
+            <div class="entry-doc">
+                <p>A pseudorandom value, paired with its <code>Generator</code>&#39;s output state.</p>
+                <p>This is required to chain multiple calls together passing the updated state.</p>
+            </div>
+        </article>
+        <article class="entry entry-type" id="Random.State">
+            <h2><a href="#Random.State" class="entry-anchor" aria-label="Permalink to State"><svg class="link-icon"><use href="#link-icon"/></svg></a> <a href="#Random.State" class="entry-name-link">State</a></h2>
+            <div class="entry-doc">
+                <p>Internal state for Generators</p>
+            </div>
+        </article>
+        </div>
+        <footer><p>Made by people who like to make nice things.</p></footer>
+    </main>
+</body>
+</html>

--- a/www/0.6.0/search.js
+++ b/www/0.6.0/search.js
@@ -1,0 +1,327 @@
+const toggleSidebarEntryActive = (moduleName) => {
+  let sidebar = document.getElementById("sidebar-nav");
+
+  if (sidebar != null) {
+    // Un-hide everything
+    sidebar.querySelectorAll(".sidebar-entry").forEach((entry) => {
+      let link = entry.querySelector(".sidebar-module-link");
+      if (moduleName === link.dataset.moduleName) {
+        link.classList.toggle("active");
+      }
+    });
+  }
+};
+
+const setupSidebarNav = () => {
+  // Re-hide all the sub-entries except for those of the current module
+  let currentModuleName = document.querySelector(".module-name").textContent;
+  toggleSidebarEntryActive(currentModuleName);
+
+  // Use event delegation for entry toggles and sidebar group toggles
+  document.addEventListener("click", (e) => {
+    // Handle entry toggle buttons
+    if (e.target.classList.contains("entry-toggle")) {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      const moduleName = e.target.parentElement.dataset.moduleName;
+      toggleSidebarEntryActive(moduleName);
+      return;
+    }
+
+    // Handle sidebar group name clicks — toggle expanded and navigate
+    const groupName = e.target.closest(".sidebar-type-name");
+    if (groupName) {
+      const group = groupName.closest(".sidebar-type");
+      if (group) {
+        group.classList.toggle("expanded");
+      }
+      return;
+    }
+  });
+
+  // Auto-expand groups in the active module
+  const activeModule = document.querySelector(".sidebar-module-link.active");
+  if (activeModule) {
+    const subEntries = activeModule.parentElement?.querySelector(".sidebar-sub-entries");
+    if (subEntries) {
+      // Mark groups in active module as expanded
+      subEntries.querySelectorAll(".sidebar-type").forEach((group) => {
+        group.classList.add("expanded");
+      });
+    }
+  }
+};
+
+const setupSearch = () => {
+  let searchTypeAhead = document.getElementById("search-type-ahead");
+  let searchBox = document.getElementById("module-search");
+  let searchForm = document.getElementById("module-search-form");
+  let topSearchResultListItem = undefined;
+
+  // Hide the results whenever anyone clicks outside the search results,
+  // or on a specific search result.
+  window.addEventListener("click", function (event) {
+    if (!searchForm?.contains(event.target) || event.target.closest("#search-type-ahead a")) {
+      searchTypeAhead.classList.add("hidden");
+    }
+  });
+
+  if (searchBox != null) {
+    function searchKeyDown(event) {
+      switch (event.key) {
+        case "ArrowDown": {
+          event.preventDefault();
+
+          const focused = document.querySelector(
+            "#search-type-ahead > li:not([class*='hidden']) > a:focus",
+          );
+
+          // Find the next element to focus.
+          let nextToFocus = focused?.parentElement?.nextElementSibling;
+
+          while (
+            nextToFocus != null &&
+            nextToFocus.classList.contains("hidden")
+          ) {
+            nextToFocus = nextToFocus.nextElementSibling;
+          }
+
+          if (nextToFocus == null) {
+            // If none of the links were focused, focus the first one.
+            // Also if we've reached the last one in the list, wrap around to the first.
+            document
+              .querySelector(
+                "#search-type-ahead > li:not([class*='hidden']) > a",
+              )
+              ?.focus();
+          } else {
+            nextToFocus.querySelector("a").focus();
+          }
+
+          break;
+        }
+        case "ArrowUp": {
+          event.preventDefault();
+
+          const focused = document.querySelector(
+            "#search-type-ahead > li:not([class*='hidden']) > a:focus",
+          );
+
+          // Find the next element to focus.
+          let nextToFocus = focused?.parentElement?.previousElementSibling;
+          while (
+            nextToFocus != null &&
+            nextToFocus.classList.contains("hidden")
+          ) {
+            nextToFocus = nextToFocus.previousElementSibling;
+          }
+
+          if (nextToFocus == null) {
+            // If none of the links were focused, or we're at the first one, focus the search box again.
+            searchBox?.focus();
+          } else {
+            // If one of the links was focused, focus the previous one
+            nextToFocus.querySelector("a").focus();
+          }
+
+          break;
+        }
+        case "Enter": {
+          // In case this is just an anchor link (which will move the scroll bar but not
+          // reload the page), hide the search bar.
+          searchTypeAhead.classList.add("hidden");
+          break;
+        }
+      }
+    }
+
+    searchForm.addEventListener("keydown", searchKeyDown);
+
+    function search() {
+      topSearchResultListItem = undefined;
+      let text = searchBox.value.toLowerCase(); // Search is case-insensitive.
+
+      if (text === "") {
+        searchTypeAhead.classList.add("hidden");
+      } else {
+        let totalResults = 0;
+        // Show/hide all the sub-entries within each module (top-level functions etc.)
+        searchTypeAhead.querySelectorAll("li").forEach((entry) => {
+          const entryModule = entry
+            .querySelector(".type-ahead-module-name")
+            ?.textContent?.toLowerCase() ?? "";
+          const entryName = entry
+            .querySelector(".type-ahead-def-name")
+            .textContent.toLowerCase();
+          const entrySignature = entry
+            .querySelector(".type-ahead-signature")
+            ?.textContent?.toLowerCase()
+            ?.replace(/\s+/g, "");
+
+          const qualifiedEntryName = entryModule
+            ? `${entryModule}.${entryName}`
+            : entryName;
+
+          if (
+            qualifiedEntryName.includes(text) ||
+            entrySignature?.includes(text.replace(/\s+/g, ""))
+          ) {
+            totalResults++;
+            entry.classList.remove("hidden");
+            if (topSearchResultListItem === undefined) {
+              topSearchResultListItem = entry;
+            }
+          } else {
+            entry.classList.add("hidden");
+          }
+        });
+        if (totalResults < 1) {
+          searchTypeAhead.classList.add("hidden");
+        } else {
+          searchTypeAhead.classList.remove("hidden");
+        }
+      }
+    }
+
+    searchBox.addEventListener("input", search);
+
+    search();
+
+    function searchSubmit(e) {
+      // pick the top result if the user submits search form
+      e.preventDefault();
+      if (topSearchResultListItem !== undefined) {
+        let topSearchResultListItemAnchor =
+          topSearchResultListItem.querySelector("a");
+        if (topSearchResultListItemAnchor !== null) {
+          topSearchResultListItemAnchor.click();
+        }
+      }
+    }
+    searchForm.addEventListener("submit", searchSubmit);
+
+    // Capture '/' keypress for quick search
+    window.addEventListener("keyup", (e) => {
+      if (e.key === "s" && document.activeElement !== searchBox) {
+        e.preventDefault();
+        searchBox.focus();
+        searchBox.value = "";
+      }
+
+      if (e.key === "Escape") {
+        if (document.activeElement === searchBox) {
+          // De-focus and clear input box
+          searchBox.value = "";
+          searchBox.blur();
+        } else {
+          // Hide the search results
+          searchTypeAhead.classList.add("hidden");
+
+          if (searchTypeAhead.contains(document.activeElement)) {
+            searchBox.focus();
+          }
+        }
+      }
+    });
+  }
+};
+
+const isTouchSupported = () => {
+  try {
+    document.createEvent("TouchEvent");
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+const setupCodeBlocks = () => {
+  // Select all <samp> elements that are children of <pre> elements
+  const codeBlocks = document.querySelectorAll("pre > samp");
+
+  // Iterate over each code block
+  codeBlocks.forEach((codeBlock) => {
+    // Create a "Copy" button
+    const copyButton = document.createElement("button");
+    copyButton.classList.add("copy-button");
+    copyButton.textContent = "Copy";
+
+    // Add event listener to copy button
+    copyButton.addEventListener("click", () => {
+      const codeText = codeBlock.innerText;
+      navigator.clipboard.writeText(codeText);
+      copyButton.textContent = "Copied!";
+      copyButton.classList.add("copy-button-copied");
+      copyButton.addEventListener("mouseleave", () => {
+        copyButton.textContent = "Copy";
+        copyButton.classList.remove("copy-button-copied");
+      });
+    });
+
+    // Create a container for the copy button and append it to the document
+    const buttonContainer = document.createElement("div");
+    buttonContainer.classList.add("button-container");
+    buttonContainer.appendChild(copyButton);
+    codeBlock.parentNode.insertBefore(buttonContainer, codeBlock);
+
+    // Hide the button container by default
+    buttonContainer.style.display = "none";
+
+    if (isTouchSupported()) {
+      // Show the button container on click for touch support (e.g. mobile)
+      document.addEventListener("click", (event) => {
+        if (event.target.closest("pre > samp") !== codeBlock) {
+          buttonContainer.style.display = "none";
+        } else {
+          buttonContainer.style.display = "block";
+        }
+      });
+    } else {
+      // Show the button container on hover for non-touch support (e.g. desktop)
+      codeBlock.parentNode.addEventListener("mouseenter", () => {
+        buttonContainer.style.display = "block";
+      });
+
+      codeBlock.parentNode.addEventListener("mouseleave", () => {
+        buttonContainer.style.display = "none";
+      });
+    }
+  });
+};
+
+const setupSidebarToggle = () => {
+  let body = document.body;
+  const sidebarOpen = "sidebar-open";
+  const removeOpenClass = () => {
+    body.classList.remove(sidebarOpen);
+    document.body
+      .querySelector("main")
+      .removeEventListener("click", removeOpenClass);
+  };
+  Array.from(document.body.querySelectorAll(".menu-toggle")).forEach(
+    (menuToggle) => {
+      menuToggle.addEventListener("click", (e) => {
+        body.classList.toggle(sidebarOpen);
+        e.stopPropagation();
+        if (body.classList.contains(sidebarOpen)) {
+          document.body.addEventListener("click", removeOpenClass);
+        }
+      });
+    },
+  );
+};
+
+// Only run setup functions if their required elements are present
+if (document.querySelector(".module-name")) {
+  setupSidebarNav();
+}
+
+if (document.getElementById("module-search")) {
+  setupSearch();
+}
+
+setupCodeBlocks();
+
+if (document.querySelector(".menu-toggle")) {
+  setupSidebarToggle();
+}

--- a/www/0.6.0/styles.css
+++ b/www/0.6.0/styles.css
@@ -1,0 +1,1240 @@
+:root {
+  /* Sidebar dropdown triangle, used as a mask on `.entry-toggle::before` so it
+     follows the toggle's color. Two back-to-back right triangles split along the
+     triangle's axis; the lower half is masked to ~55% alpha so it reads a touch
+     lighter than the upper half. */
+  --toggle-triangle: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3E%3Cpath d='M1.5 1L1.5 4L7 4Z'/%3E%3Cpath d='M1.5 4L1.5 7L7 4Z' fill-opacity='.55'/%3E%3C/svg%3E");
+  /* WCAG AAA Compliant colors - important that luminance (the l in hsl) is 18% for font colors against the bg's luminance of 96-97% when the font-size is at least 14pt */
+  --code-bg: hsl(262 33% 96% / 1);
+  --code-color: #000;
+  --gray: hsl(0 0% 18% / 1);
+  --orange: hsl(25 100% 18% / 1);
+  --green: hsl(115 100% 18% / 1);
+  --cyan: hsl(190 100% 18% / 1);
+  --blue: #05006d;
+  --violet: #7c38f5;
+  --violet-bg: hsl(262.22deg 87.1% 96%);
+  --magenta: #a20031;
+  --link-hover-color: #333;
+  --link-color: var(--violet);
+  --code-link-color: var(--violet);
+  --text-color: #000;
+  --text-hover-color: var(--violet);
+  --body-bg-color: #ffffff;
+  --border-color: #717171;
+  --faded-color: #4c4c4c;
+  --font-sans: -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
+  --font-mono: SFMono-Regular, Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  --sidebar-width: clamp(280px, 25dvw, 500px);
+  --module-search-height: 56px;
+  --module-search-padding-height: 16px;
+  --module-search-form-padding-width: 20px;
+  /* Total vertical space occupied by #module-search-form (input + form padding + margin-bottom).
+     Used both as scroll-padding-top on desktop (sticky form) and padding-top on mobile (fixed form). */
+  --module-search-form-height: calc(var(--module-search-height) + 32px);
+  --sidebar-bg-color: hsl(from var(--violet-bg) h calc(s * 1.05) calc(l * 0.95));
+
+  /* Semantic size tokens */
+  --entry-anchor-offset: 28px; /* space reserved left of entry headings for the permalink anchor */
+  --icon-size: 48px;           /* logo, menu-toggle, entry-toggle tap targets */
+
+  /* Semi-transparent tints derived from palette colors */
+  --violet-border-subtle: rgb(from var(--violet) r g b / .40);
+  --violet-border-hover: rgb(from var(--violet) r g b / .60);
+  --gray-border-subtle: rgb(from var(--gray) r g b / .30);
+
+  /* Search input border — distinct from --violet-bg so it's visible on a white background */
+  --search-border-color: hsl(262 50% 72%);
+
+  /* Type scale: 1.33x multiplier for clear hierarchy */
+  --font-xs: 0.75rem;
+  --font-sm: 0.875rem;
+  --font-base: 1rem;
+  --font-lg: 1.3125rem;
+  --font-xl: 1.75rem;
+  --font-2xl: 2.3125rem;
+
+  /* Font weights */
+  --weight-normal: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --weight-bold: 700;
+}
+
+
+a {
+  color: var(--violet);
+}
+
+table tr th,
+table tr td {
+  border: 1px solid var(--gray);
+  padding: 6px 13px;
+}
+
+.logo svg {
+  height: var(--icon-size);
+  width: var(--icon-size);
+  fill: var(--violet);
+}
+
+.logo:hover {
+  text-decoration: none;
+}
+
+.logo svg:hover {
+  fill: var(--link-hover-color);
+}
+
+.pkg-full-name {
+  display: flex;
+  align-items: center;
+  font-size: var(--font-xl);
+  margin: 0 8px;
+  font-weight: var(--weight-normal);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Entry signature styling - not a heading element */
+.entry-signature {
+  font-family: var(--font-mono);
+  background-color: var(--violet-bg);
+  color: var(--text-color);
+  margin-bottom: 16px;
+  padding: 12px 16px;
+  border-left: 4px solid var(--violet);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  white-space: pre-wrap;
+  position: relative;
+  overflow: visible;
+}
+
+
+.entry-signature-code {
+  background: none;
+  font-size: inherit;
+  flex: 1;
+}
+
+.sig-arrow {
+  white-space: nowrap;
+}
+
+/* Type definition block shown below heading for nominal types (e.g. Try := ...) */
+.entry-type-def {
+  display: block;
+  font-family: var(--font-mono);
+  background-color: var(--violet-bg);
+  color: var(--text-color);
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  white-space: pre-wrap;
+  font-size: var(--font-base);
+  line-height: 1.5;
+}
+
+/* Match the entry-anchor-offset left margin applied to entry headings (.entry h2-h6) so the
+   type definition aligns with the heading name above it. */
+.entry > .entry-type-def {
+  margin-left: var(--entry-anchor-offset);
+}
+
+.entry-signature-code strong {
+    color: var(--text-color);
+    font-weight: var(--weight-semibold);
+}
+
+.entry-anchor {
+  visibility: hidden;
+  color: var(--violet);
+  text-decoration: none;
+  user-select: none;
+  transition: visibility 6s;
+  position: absolute;
+  left: calc(-1 * var(--entry-anchor-offset));
+  display: flex;
+  align-items: center;
+  height: 100%;
+  top: 0;
+}
+
+.entry-anchor .link-icon {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
+  vertical-align: middle;
+}
+
+.entry h2,
+.entry h3,
+.entry h4,
+.entry h5,
+.entry h6 {
+  margin-left: var(--entry-anchor-offset);
+  position: relative;
+}
+
+.entry-signature:hover .entry-anchor,
+.entry h2:hover .entry-anchor,
+.entry h3:hover .entry-anchor,
+.entry h4:hover .entry-anchor,
+.entry h5:hover .entry-anchor,
+.entry h6:hover .entry-anchor {
+  visibility: visible;
+}
+
+.entry-name-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+
+.entry-group-header {
+    color: var(--violet);
+    padding: 8px 0;
+    margin-top: 0;
+}
+
+/* Hierarchical entry layout */
+.entry {
+    position: relative;
+    margin-bottom: 24px;
+}
+
+/* Targets of anchor-link navigation (permalink clicks, # references). */
+.entry[id],
+.entry-group[id] {
+  /* Offset so the target lands below the sticky search bar. */
+  scroll-margin-top: var(--module-search-form-height);
+}
+
+.entry-children-container {
+    margin-top: 16px;
+    margin-left: var(--entry-anchor-offset);
+}
+
+.entry-doc {
+    padding-left: 20px;
+}
+
+/* Entry type vs value styling */
+.entry-type > .entry-signature {
+    font-weight: var(--weight-semibold);
+    background-color: var(--violet-bg);
+    border-left: 4px solid var(--violet);
+    font-size: var(--font-base);
+    line-height: 1.5;
+}
+
+.entry-value > .entry-signature {
+    font-weight: var(--weight-normal);
+    background-color: transparent;
+    border-left: 4px solid rgb(from var(--violet) r g b);
+    font-size: var(--font-base);
+    line-height: 1.5;
+}
+
+
+.pkg-full-name a {
+  padding-top: 12px;
+  padding-bottom: 16px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+a {
+  text-decoration: none;
+}
+
+a:hover,
+a:hover code {
+  text-decoration: underline;
+  text-decoration-thickness: 3px;
+  text-underline-offset: 5px;
+}
+
+.pkg-and-logo {
+  min-width: 0; /* necessary for text-overflow: ellipsis to work in descendants */
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  background-color: var(--violet-bg);
+  padding: 16px;
+}
+
+.pkg-and-logo a,
+.pkg-and-logo a:visited {
+  color: var(--violet);
+}
+
+.pkg-and-logo a:hover {
+  color: var(--link-hover-color);
+  text-decoration: none;
+}
+
+body {
+  display: grid;
+  grid-template-columns:
+      [sidebar] var(--sidebar-width)
+      [main-content] 1fr
+      [content-end];
+  grid-template-rows: 1fr;
+  height: 100dvh;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-sans);
+  font-size: var(--font-sm);
+  line-height: 1.6;
+  color: var(--text-color);
+  background-color: var(--body-bg-color);
+  overflow: hidden;
+}
+
+main {
+  grid-column-start: main-content;
+  grid-column-end: content-end;
+  box-sizing: border-box;
+  position: relative;
+  font-size: var(--font-base);
+  line-height: 1.6;
+  margin-top: 2px;
+  padding: 16px;
+  padding-top: 0px;
+  /* necessary for text-overflow: ellipsis to work in descendants */
+  min-width: 0;
+  overflow-x: auto;
+  /* fixes issues with horizontal scroll in cases where word is too long,
+  like in one of the examples at https://www.roc-lang.org/builtins/Num#Dec */
+  overflow-y: auto;
+  display: grid;
+  --main-content-width: clamp(100px, calc(100% - 32px), 70ch);
+  grid-template-columns: [main-start] minmax(16px,1fr) [main-content-start] var(--main-content-width) [main-content-end] minmax(16px,1fr) [main-end];
+  grid-template-rows: auto 1fr auto;
+  scrollbar-color: var(--violet) var(--body-bg-color);
+  scrollbar-gutter: stable both-edges;
+}
+
+main > * {
+    grid-column-start: main-content-start;
+    grid-column-end: main-content-end;
+}
+
+.main-content {
+    min-width: 0;
+}
+
+/* Module links on the package index page (/index.html) */
+.index-module-links {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+    font-size: large;
+}
+
+section:not(.langref-article) {
+  padding: 0px 0px 16px 20px;
+}
+
+section blockquote {
+  font-style: italic;
+  position: relative;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+section blockquote:before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 2px;
+  height: 100%;
+  background-color: var(--gray);
+}
+
+
+section > *:last-child {
+  margin-bottom: 0;
+}
+
+section:not(.langref-article) h1,
+section:not(.langref-article) h2,
+section:not(.langref-article) h3,
+section:not(.langref-article) h4,
+section:not(.langref-article) p {
+padding: 0px 16px;
+}
+
+/* Language reference articles reuse the module-page chrome and layout. These
+   rules give the converted Markdown block elements (lists, tables, code blocks)
+   their horizontal rhythm. Headings and the page title use the page font rather
+   than the monospace reserved for code identifiers. */
+.module-name.langref-title,
+.langref-article h1,
+.langref-article h2,
+.langref-article h3,
+.langref-article h4,
+.langref-article h5,
+.langref-article h6 {
+  font-family: var(--font-sans);
+}
+
+.langref-article ul,
+.langref-article ol {
+  margin: 12px 0;
+  padding-left: 40px;
+}
+
+.langref-article li {
+  margin: 4px 0;
+}
+
+.langref-article li > ul,
+.langref-article li > ol {
+  margin: 4px 0;
+}
+
+.langref-article pre {
+  margin-left: 16px;
+  margin-right: 16px;
+}
+
+.langref-article table {
+  border-collapse: collapse;
+  margin: 16px;
+}
+
+#sidebar-nav {
+    grid-column-start: sidebar;
+    grid-column-end: main-content;
+    position: relative;
+    display: grid;
+    grid-template-rows: min-content 1fr;
+    box-sizing: border-box;
+    width: 100%;
+    background-color: var(--sidebar-bg-color);
+    transition: all 1s linear;
+}
+
+#sidebar-nav .module-links-container {
+    position: relative;
+}
+
+
+#sidebar-nav .module-links {
+    position: absolute;
+    inset: 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+    scrollbar-color: var(--violet) var(--sidebar-bg-color);
+    scrollbar-gutter: stable;
+    padding: 16px 8px;
+    transition: all .2s linear;
+    list-style: none;
+}
+
+p {
+  overflow-wrap: break-word;
+  margin: 24px 0;
+}
+
+footer {
+  font-size: var(--font-sm);
+  box-sizing: border-box;
+  padding: 16px 0px 0px;
+}
+
+footer p {
+  display: inline-block;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.sidebar-entry ul {
+  list-style-type: none;
+  margin: 0;
+}
+
+.sidebar-entry a {
+  box-sizing: border-box;
+  min-height: 40px;
+  min-width: 48px;
+  padding-left: 16px;
+  font-family: var(--font-mono);
+}
+
+.sidebar-entry a,
+.sidebar-entry a:visited {
+  color: var(--text-color);
+}
+
+.sidebar-sub-entries {
+    font-size: var(--font-sm);
+    display: none;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.active + .sidebar-sub-entries {
+    display: block;
+}
+
+/* When a module entry is itself nested inside another entry's sub-entry list
+   (e.g. the builtin type modules under "Builtin Types"), indent its members so
+   they sit underneath their type rather than level with it. Top-level modules
+   and types are not descendants of a sub-entry list, so they are unaffected. */
+.sidebar-sub-entries .sidebar-entry > .sidebar-sub-entries {
+    margin-left: 22px;
+}
+
+.sidebar-sub-entries a {
+  display: flex;
+  align-items: center;
+  line-height: 24px;
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-left: 20px;
+  padding-left: 16px;
+  /* Transparent by default so the indent is consistent; only values/methods
+     (`.sidebar-value`) get a visible bar — nested types, type-module entries,
+     and language-reference links do not. */
+  border-left: 4px solid transparent;
+  white-space: nowrap;
+}
+
+.sidebar-sub-entries a.sidebar-value {
+  border-left-color: var(--gray-border-subtle);
+  padding-left: 20px;
+}
+
+.sidebar-sub-entries > li:first-child > a {
+    margin-top: 8px;
+    padding-top: 0;
+}
+
+.sidebar-sub-entries > li:last-child > a {
+    margin-bottom: 8px;
+    padding-bottom: 0;
+}
+
+.sidebar-sub-entries a:hover {
+    color: var(--violet);
+    text-decoration: none;
+}
+
+.sidebar-sub-entries a.sidebar-value:hover {
+    border-left-color: var(--violet-border-hover);
+}
+
+/* Builtin docs only (the langref-enabled site): the "Builtin Types" and
+   "Language Reference" sidebar entries, and the langref article links, are
+   prose labels rather than code identifiers, so they use the page font instead
+   of the monospace used elsewhere in the sidebar. Inline `code` inside a
+   langref article link keeps its monospace styling via the `code` rule. */
+.pkg-full-name.prose-label,
+.sidebar-module-link.prose-label,
+.langref-articles a {
+  font-family: var(--font-sans);
+}
+
+.sidebar-type {
+    margin-left: 0;
+}
+
+.sidebar-type-name {
+    font-weight: var(--weight-medium);
+    font-size: var(--font-base);
+    cursor: pointer;
+    text-decoration: none;
+    color: inherit;
+    display: inline-block;
+    padding-left: 16px;
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    box-sizing: border-box;
+}
+
+.sidebar-type-name:hover {
+    color: var(--violet);
+}
+
+.sidebar-type > .sidebar-sub-entries {
+    max-height: 0;
+    overflow: hidden;
+    margin-left: 0;
+    transition: max-height 200ms ease-out;
+}
+
+.sidebar-type.expanded > .sidebar-sub-entries {
+    max-height: 10000px;
+    transition: max-height 200ms ease-in;
+}
+
+.module-name {
+  font-size: var(--font-2xl);
+  line-height: 1.2;
+  font-family: var(--font-mono);
+  font-weight: var(--weight-bold);
+  margin-top: 36px;
+  color: var(--violet);
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-mono);
+}
+
+h1 {
+  margin-bottom: 30px;
+}
+
+h2 {
+  font-size: var(--font-xl);
+  margin-bottom: 0;
+}
+
+h3 {
+  font-size: var(--font-lg);
+  margin-bottom: 0;
+}
+
+h4 {
+  font-size: var(--font-base);
+  margin-bottom: 0;
+  margin-top: 23px;
+}
+
+h5 {
+  font-size: var(--font-base);
+  margin-bottom: 0;
+  margin-top: 23px;
+}
+
+h6 {
+  font-size: var(--font-base);
+  margin-bottom: 0;
+  margin-top: 23px;
+}
+
+.module-name a,
+.module-name a:visited {
+color: inherit;
+}
+
+.module-name a:hover {
+  color: var(--link-hover-color);
+}
+
+a.sidebar-module-link {
+  box-sizing: border-box;
+  font-size: var(--font-base);
+  line-height: 1.5;
+  font-family: var(--font-mono);
+  font-weight: var(--weight-normal);
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sidebar-module-link:hover {
+    text-decoration: none;
+
+    span:hover {
+        color: var(--violet);
+    }
+}
+
+.sidebar-module-link span {
+    display: inline-block;
+    flex-grow: 1;
+}
+
+.sidebar-module-link.active {
+  font-weight: var(--weight-bold);
+}
+
+.sidebar-module-link > .entry-toggle {
+    background-color: transparent;
+    appearance: none;
+    border: none;
+    color: transparent;
+    color: rgba(from var(--text-color) r g b / .5);
+    transition: all 80ms linear;
+    text-decoration: none;
+    font-size: 0.8rem;
+    cursor: pointer;
+    padding: 8px 16px;
+
+    &:hover {
+        color: var(--violet);
+    }
+}
+
+/* The triangle itself: a single SVG (`--toggle-triangle`) masked by the toggle's
+   current color, so it tracks the gray/hover-violet transitions. */
+.entry-toggle::before {
+    content: "";
+    display: inline-block;
+    width: 0.85rem;
+    height: 0.85rem;
+    vertical-align: middle;
+    background-color: currentColor;
+    -webkit-mask: var(--toggle-triangle) center / contain no-repeat;
+    mask: var(--toggle-triangle) center / contain no-repeat;
+}
+
+.sidebar-entry:hover > a > .entry-toggle,
+.sidebar-module-link:hover > .entry-toggle {
+    color: var(--text-color);
+}
+
+/* Nested module toggles (e.g. the builtin types under "Builtin Types") sit in a
+   smaller-font line and read a touch low; nudge them up to center on the label.
+   `top` offsets the box before the `rotate` spins it, so both states stay aligned. */
+.sidebar-sub-entries .entry-toggle {
+    position: relative;
+    top: -2px;
+}
+
+.active .entry-toggle {
+    rotate: 90deg;
+}
+
+a,
+a:visited {
+  color: var(--link-color);
+}
+
+
+code {
+  font-family: var(--font-mono);
+  color: var(--code-color);
+  background-color: var(--code-bg);
+  display: inline-block;
+}
+
+p code {
+  padding: 0 4px;
+}
+
+/* Inline code in headings should blend in with the heading, not look like a
+   highlighted code chip. */
+h1 code,
+h2 code,
+h3 code,
+h4 code,
+h5 code,
+h6 code {
+  background-color: transparent;
+  padding: 0;
+}
+
+code a,
+a code {
+  text-decoration: none;
+  color: var(--code-link-color);
+  background: none;
+  padding: 0;
+  font-weight: bold; /* Important for AAA compliance while keeping color distinct */
+}
+
+code a .type,
+code a:hover .type,
+code a:visited .type {
+  color: var(--green) !important;
+}
+
+code a:visited,
+a:visited code {
+  color: var(--code-link-color);
+}
+
+pre {
+  margin: 36px 0;
+  padding: 8px 16px;
+  box-sizing: border-box;
+  background-color: var(--code-bg);
+  position: relative;
+  word-wrap: normal;
+}
+
+pre>code {
+    overflow-x: auto;
+    display: block;
+    scrollbar-color: var(--violet) var(--code-bg);
+    scrollbar-width: thin;
+    scrollbar-gutter: stable;
+}
+
+.hidden {
+  /* Use !important to win all specificity fights. */
+  display: none !important;
+}
+
+#module-search-form {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: sticky;
+  box-sizing: border-box;
+  padding: 12px 0;
+  background-color: var(--body-bg-color);
+  top: 0;
+  z-index: 1;
+  margin-bottom: 8px;
+}
+
+
+.menu-toggle {
+    display: none;
+    margin-right: 8px;
+    appearance: none;
+    background-color: transparent;
+    outline: none;
+    border: none;
+    color: var(--violet);
+    padding: 0;
+    cursor: pointer;
+}
+
+.menu-toggle svg {
+    height: var(--icon-size);
+    width: var(--icon-size);
+    fill: var(--violet);
+}
+
+
+#module-search,
+#module-search-nojs,
+#module-search:focus {
+  opacity: 1;
+  padding: 12px 16px;
+  height: var(--module-search-height);
+}
+
+#module-search,
+#module-search-nojs {
+  display: block;
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  font-size: var(--font-base);
+  line-height: 18px;
+  color: var(--text-color);
+  background-color: var(--body-bg-color);
+  font-family: var(--font-sans);
+  border: 2px solid var(--search-border-color);
+}
+
+/* Hidden when JS is enabled. The <noscript><style> in #module-search-form
+   re-enables it (and hides #module-search) when JS is disabled. */
+#module-search-nojs {
+  display: none;
+}
+
+#module-search::placeholder,
+#module-search-nojs::placeholder {
+  color: var(--faded-color);
+  opacity: 1;
+}
+
+#module-search:focus, #module-search:hover {
+  outline: 2px solid var(--violet);
+}
+
+#search-type-ahead {
+  font-family: var(--font-mono);
+  display: flex;
+  gap: 0px;
+  flex-direction: column;
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
+  box-sizing: border-box;
+  z-index: 100;
+  background-color: var(--body-bg-color);
+  border: 2px solid var(--violet);
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+#search-type-ahead .type-ahead-link {
+  font-size: var(--font-base);
+  color: var(--text-color);
+  line-height: 2em;
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  padding: 4px 8px;
+
+  display: block;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+
+
+  span {
+    margin: 0px;
+  }
+
+  .type-ahead-module-name, .type-ahead-def-name {
+    color: var(--violet);
+    font-size: var(--font-base);
+  }
+}
+
+#search-type-ahead li {
+  box-sizing: border-box;
+  position: relative;
+}
+
+#search-type-ahead a:focus {
+  outline: none;
+  background: var(--violet-bg);
+}
+
+
+@media (prefers-color-scheme: dark) {
+  :root {
+      /* WCAG AAA Compliant colors */
+    --code-bg: hsl(228.95deg 37.25% 15%);
+    --gray: hsl(0 0% 70% / 1);
+    --orange: hsl(25 98% 70% / 1);
+    --green: hsl(115 40% 70% / 1);
+    --cyan: hsl(176 84% 70% / 1);
+    --blue: hsl(243 43% 80% / 1);
+    --violet: #caadfb;
+    --violet-bg: hsl(262 25% 15% / 1);
+    --magenta: hsl(348 79% 80% / 1);
+      --link-hover-color: #fff;
+
+      --link-color: var(--violet);
+      --code-link-color: var(--violet);
+      --text-color: #eaeaea;
+      --body-bg-color: hsl(from var(--violet-bg) h s calc(l * .5));
+      --border-color: var(--gray);
+      --code-color: #eeeeee;
+      --logo-solid: #8f8f8f;
+      --faded-color: #bbbbbb;
+      --sidebar-bg-color: hsl(from var(--violet-bg) h calc(s * 1.1) calc(l * 0.75));
+      --search-border-color: hsl(262 35% 40%);
+  }
+
+  html {
+      scrollbar-color: #8f8f8f #2f2f2f;
+  }
+
+  /* In dark mode "lighter" means more of the near-white text color, i.e. a
+     higher alpha (the opposite of light mode, where lighter means fading toward
+     the light background). */
+  .sidebar-module-link > .entry-toggle {
+      color: rgba(from var(--text-color) r g b / .8);
+  }
+}
+
+@media only screen and (max-width: 768px) {
+    :root {
+        --sidebar-width: clamp(280px, 50dvw, 385px);
+    }
+    body {
+        display: block;
+        overflow-y: auto;
+        overflow-x: hidden;
+    }
+
+    html {
+        scroll-padding-top: var(--module-search-form-height);
+    }
+
+    #sidebar-nav {
+        left: calc(-1 * var(--sidebar-width));
+        top: 0;
+        bottom: 0;
+        position: fixed;
+        z-index: 2;
+        transition: all .2s linear;
+    }
+
+    .entry-toggle {
+        height: var(--icon-size);
+        width: var(--icon-size);
+    }
+
+    body.sidebar-open #sidebar-nav {
+        left: 0;
+    }
+
+    main {
+        display: flex;
+        flex-direction: column;
+        margin: 0;
+        min-height: 100dvh;
+        --main-content-width: minmax(calc(100% - 32px), 60ch);
+    }
+
+    main > .main-content {
+        flex: 1;
+    }
+
+    #module-search-form {
+        padding: 16px 16px;
+        height: auto;
+        margin-bottom: 16px;
+        grid-column-start: main-content-start;
+        grid-column-end: main-content-end;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        justify-content: flex-start;
+    }
+
+    #module-search-form:has(#module-search:focus) .menu-toggle {
+        max-width: 0;
+        margin-left: 0;
+        opacity: 0;
+    }
+
+    .entry-anchor {
+        display: none;
+    }
+
+    .entry-signature {
+        padding-left: 8px;
+        padding-right: 8px;
+    }
+
+    .menu-toggle {
+        display: block;
+        flex-shrink: 0;
+        max-width: var(--icon-size);
+        overflow: hidden;
+        margin-left: 16px;
+        appearance: none;
+        background-color: transparent;
+        outline: none;
+        border: none;
+        color: var(--violet);
+        padding: 0;
+        cursor: pointer;
+        touch-action: manipulation;
+        transition: max-width 0.2s ease, margin-left 0.2s ease, opacity 0.2s ease;
+    }
+
+    #module-search,
+    #module-search-nojs {
+        flex: 1;
+        width: auto;
+    }
+
+    .pkg-full-name {
+        font-size: 20px;
+        padding-bottom: 14px;
+    }
+
+    .pkg-full-name a {
+        vertical-align: middle;
+        padding: 18px 0;
+    }
+
+    .logo {
+        width: 50px;
+        height: 54px;
+    }
+
+    .module-name {
+        font-size: var(--font-2xl);
+        margin-top: 8px;
+        margin-bottom: 8px;
+        /* Align with the left border of #module-search-form's input.
+           main now has no margin and padding-left: 18px, so content starts at x=18;
+           the fixed search form's input border sits at x=16 (form padding-left). */
+        margin-left: -2px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    /* Reduce section's desktop 20px left padding on mobile. */
+    section {
+        padding-left: 7px;
+    }
+
+    /* Reduce var(--entry-anchor-offset) left margins that reserve space for .entry-anchor
+       (which is hidden on mobile). Applies to entry headings, the type-def
+       block aligned with them, and the children container nested below. */
+    .entry h2,
+    .entry h3,
+    .entry h4,
+    .entry h5,
+    .entry h6,
+    .entry > .entry-type-def,
+    .entry-children-container {
+        margin-left: 8px;
+    }
+
+    /* Full-bleed code blocks */
+    pre {
+        margin-left: -24px;
+        margin-right: -24px;
+    }
+
+    main {
+        padding: 18px;
+        font-size: var(--font-base);
+        padding-top: var(--module-search-form-height);
+    }
+
+    #sidebar-nav {
+        margin-top: 0;
+        padding-left: 0;
+        width: var(--sidebar-width);
+    }
+
+    h3 {
+        font-size: 18px;
+        margin: 0;
+        padding: 0;
+    }
+
+    h4 {
+        font-size: var(--font-base);
+    }
+
+    body {
+        margin: 0;
+        min-width: 320px;
+        max-width: 100dvw;
+    }
+
+    .pkg-and-logo {
+        padding-block: 4px;
+    }
+
+    .pkg-full-name {
+        flex-grow: 1;
+    }
+
+    .pkg-full-name a {
+        padding-top: 24px;
+        padding-bottom: 12px;
+    }
+}
+
+/* Comments `#` and Documentation comments `##` */
+samp .comment,
+code .comment {
+  color: var(--green);
+}
+
+/* Number, String, Tag literals */
+samp .storage.type,
+code .storage.type,
+samp .string,
+code .string,
+samp .string.begin,
+code .string.begin,
+samp .string.end,
+code .string.end,
+samp .constant,
+code .constant,
+samp .literal,
+code .literal {
+  color: var(--cyan);
+}
+
+/* Keywords and punctuation */
+samp .keyword,
+code .keyword,
+samp .punctuation.section,
+code .punctuation.section,
+samp .punctuation.separator,
+code .punctuation.separator,
+samp .punctuation.terminator,
+code .punctuation.terminator,
+samp .kw,
+code .kw {
+    color: var(--magenta);
+}
+
+/* Operators */
+samp .op,
+code .op,
+samp .keyword.operator,
+code .keyword.operator {
+  color: var(--orange);
+}
+
+/* Delimieters */
+samp .delimiter,
+code .delimiter {
+  color: var(--gray);
+}
+
+/* Variables modules and field names */
+samp .function,
+code .function,
+samp .meta.group,
+code .meta.group,
+samp .meta.block,
+code .meta.block,
+samp .lowerident,
+code .lowerident {
+  color: var(--blue);
+}
+
+/* Types, Tags, and Modules */
+samp .type,
+code .type,
+samp .meta.path,
+code .meta.path,
+samp .upperident,
+code .upperident {
+  color: var(--green);
+}
+
+samp .dim,
+code .dim {
+  opacity: 0.55;
+}
+
+.button-container {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.copy-button {
+  background: var(--code-bg);
+  border: 1px solid var(--magenta);
+  color: var(--magenta);
+  display: inline-block;
+  cursor: pointer;
+  margin: 8px;
+}
+
+.copy-button:hover {
+  border-color: var(--link-hover-color);
+  color: var(--link-hover-color);
+}
+
+/* Search container and input styling */

--- a/www/index.html
+++ b/www/index.html
@@ -5,14 +5,14 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Redirecting...</title>
         <script>
-            window.location.href = "/roc-random/0.5.0/";
+            window.location.href = "/roc-random/0.6.0/";
         </script>
     </head>
     <body>
         <noscript>
             <p>
                 If you are not automatically redirected, please
-                <a href="/roc-random/0.5.0/">click here</a>.
+                <a href="/roc-random/0.6.0/">click here</a>.
             </p>
         </noscript>
     </body>


### PR DESCRIPTION
## Summary
- update all runnable examples to depend on the published 0.6.0 roc-random bundle instead of ../package/main.roc
- add generated 0.6.0 package docs under www/0.6.0 for GitHub Pages
- redirect the Pages root and README documentation link to the 0.6.0 docs
- update docs.sh for the current roc docs --output flow

## Docs review
- generated with ./docs.sh 0.6.0, which runs roc docs package/main.roc --output=www/0.6.0
- reviewed www/0.6.0/index.html for public API entries, map2/record-builder examples, builtin cross-links, and private helper leakage
- local assets referenced by the generated page are present: favicon.svg, styles.css, search.js

## Testing
- ./docs.sh 0.6.0
- ROC=roc ./ci/all_tests.sh
- bash -n docs.sh
- git diff --check