### PR TITLE
Migrate to shared release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,10 +235,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install Roc
+        uses: roc-lang/setup-roc@bd311e2fb815a3d2255f7ee14a922f0b736e020b
+        with:
+          version: nightly-new-compiler
+
       - name: Download release docs
         uses: actions/download-artifact@v4
         with:
           name: release-docs
+
+      - name: Download release metadata
+        uses: actions/download-artifact@v4
+        with:
+          name: release-metadata
+          path: .release
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
@@ -252,17 +263,48 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
 
-      - name: Open docs follow-up PR
+      - name: Update example package URLs
+        env:
+          RELEASE_VERSION: ${{ needs.build.outputs.release_version }}
+        run: |
+          bundle_url="$(python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          bundles = json.loads(Path(".release/release-bundles.json").read_text(encoding="utf-8"))
+          if len(bundles) != 1:
+              raise SystemExit(f"expected exactly one release bundle, found {len(bundles)}")
+
+          artifact_file = bundles[0]["artifact_file"]
+          repo = os.environ["GITHUB_REPOSITORY"]
+          version = os.environ["RELEASE_VERSION"]
+          print(f"https://github.com/{repo}/releases/download/{version}/{artifact_file}")
+          PY
+          )"
+          python3 scripts/update_example_urls.py --bundle-url "$bundle_url"
+
+      - name: Validate updated examples
+        run: |
+          roc fmt --check examples
+          for example in examples/*.roc; do
+            roc check "$example" --no-cache
+            roc test "$example" --no-cache
+          done
+
+      - name: Open docs and examples follow-up PR
         uses: roc-lang/release-package/actions/create-followup-pr@bb018c8c96b439b9545db6c792adc0549cf01ee1
         with:
           release_version: ${{ needs.build.outputs.release_version }}
-          paths: www
+          paths: |
+            examples
+            www
           branch_prefix: release-followup
           base_branch: ${{ github.ref_name }}
-          commit_message: Update docs for ${{ needs.build.outputs.release_version }}
-          pr_title: Update docs for ${{ needs.build.outputs.release_version }}
+          commit_message: Update docs and examples for ${{ needs.build.outputs.release_version }}
+          pr_title: Update docs and examples for ${{ needs.build.outputs.release_version }}
           pr_body: |
             Release follow-up for ${{ needs.build.outputs.release_version }}.
 
-            Updated generated package docs and the docs index.
+            Updated generated package docs, the docs index, and checked-in example package URLs.
           github_token: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,149 +3,266 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      release_tag:
-        description: "Release tag, e.g. v0.6.0"
+      release_version:
+        description: "Release version, e.g. 0.7.0"
         required: true
         type: string
   pull_request:
 
-env:
-  ZIG_VERSION: "0.16.0"
+permissions:
+  contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.event_name == 'workflow_dispatch' && format('release-{0}', github.repository) || format('release-validate-{0}-{1}', github.repository, github.ref) }}
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 jobs:
-  build-bundle:
-    name: Build package bundle
-    runs-on: ubuntu-24.04
+  build:
+    name: Build release bundle
+    runs-on: ubuntu-latest
     outputs:
-      bundle_filename: ${{ steps.bundle.outputs.bundle_filename }}
-    defaults:
-      run:
-        shell: bash
+      release_version: ${{ steps.validate.outputs.release_version }}
+      docs_version: ${{ steps.validate.outputs.docs_version }}
+      test_matrix: ${{ steps.bundles.outputs.test_matrix }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Install Zig
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # 2.2.1
         with:
-          version: ${{ env.ZIG_VERSION }}
-          use-cache: false
+          fetch-depth: 0
 
       - name: Install Roc
         uses: roc-lang/setup-roc@bd311e2fb815a3d2255f7ee14a922f0b736e020b
         with:
           version: nightly-new-compiler
 
-      - name: Check format and package
+      - name: Validate release request
+        id: validate
+        uses: roc-lang/release-package/actions/validate-release@bb018c8c96b439b9545db6c792adc0549cf01ee1
+        with:
+          release_version: ${{ github.event_name == 'workflow_dispatch' && inputs.release_version || '' }}
+          dry_run: ${{ github.event_name != 'workflow_dispatch' }}
+          github_token: ${{ github.token }}
+
+      - name: Validate release branch
+        if: github.event_name == 'workflow_dispatch'
         run: |
-          roc fmt --check package examples
-          roc check package/main.roc
-          roc test package/main.roc
-
-      - name: Bundle package
-        id: bundle
-        run: |
-          BUNDLE_OUTPUT=$(scripts/bundle.sh --output-dir dist 2>&1)
-          echo "$BUNDLE_OUTPUT"
-
-          BUNDLE_PATH=$(echo "$BUNDLE_OUTPUT" | grep "^Created:" | awk '{print $2}')
-          BUNDLE_FILENAME=$(basename "$BUNDLE_PATH")
-
-          if [ -z "$BUNDLE_FILENAME" ]; then
-            echo "Error: could not extract bundle filename from roc bundle output"
+          if [[ "${GITHUB_REF_TYPE:-}" != "branch" ]]; then
+            echo "Release workflow must be run from a branch so generated docs can be proposed in a follow-up PR."
             exit 1
           fi
 
-          echo "bundle_filename=$BUNDLE_FILENAME" >> "$GITHUB_OUTPUT"
+      - name: Validate package
+        run: ./ci/all_tests.sh
 
-      - name: Upload package bundle artifact
+      - name: Resolve previous release
+        if: github.event_name == 'workflow_dispatch'
+        id: previous
+        uses: roc-lang/release-package/actions/resolve-previous-release@bb018c8c96b439b9545db6c792adc0549cf01ee1
+        with:
+          github_token: ${{ github.token }}
+
+      - name: Check version bump
+        uses: roc-lang/release-package/actions/run-bump-check@bb018c8c96b439b9545db6c792adc0549cf01ee1
+        with:
+          release_version: ${{ steps.validate.outputs.release_version }}
+          dry_run: ${{ github.event_name != 'workflow_dispatch' }}
+          bump_check: require
+          bump_entrypoint: package/main.roc
+          previous_url: ${{ steps.previous.outputs.previous_url }}
+
+      - name: Bundle package
+        run: ./scripts/bundle.sh --output-dir dist
+
+      - name: Prepare release bundle metadata
+        id: bundles
+        uses: roc-lang/release-package/actions/prepare-bundles@bb018c8c96b439b9545db6c792adc0549cf01ee1
+        with:
+          bundle_glob: dist/*.tar.zst
+          test_os_json: '["ubuntu-latest"]'
+
+      - name: Snapshot existing docs
+        uses: roc-lang/release-package/actions/docs-snapshot@bb018c8c96b439b9545db6c792adc0549cf01ee1
+        with:
+          docs_root: www
+
+      - name: Generate versioned docs
+        run: |
+          rm -rf "www/${{ steps.validate.outputs.docs_version }}"
+          roc docs package/main.roc --output="www/${{ steps.validate.outputs.docs_version }}"
+
+      - name: Update docs index
+        uses: roc-lang/release-package/actions/docs-index@bb018c8c96b439b9545db6c792adc0549cf01ee1
+        with:
+          docs_root: www
+          docs_version: ${{ steps.validate.outputs.docs_version }}
+
+      - name: Validate docs
+        uses: roc-lang/release-package/actions/docs-validate@bb018c8c96b439b9545db6c792adc0549cf01ee1
+        with:
+          docs_root: www
+          docs_version: ${{ steps.validate.outputs.docs_version }}
+
+      - name: Archive docs site
+        run: tar -czf "dist/roc-random-docs-${{ steps.validate.outputs.docs_version }}.tar.gz" www
+
+      - name: Upload release bundles
         uses: actions/upload-artifact@v4
         with:
-          name: package-bundle
-          path: dist/${{ steps.bundle.outputs.bundle_filename }}
-          retention-days: 30
+          name: release-bundles
+          path: .release/bundles/*
+          if-no-files-found: error
+          retention-days: 7
 
-  test-bundle:
-    name: Test package bundle (${{ matrix.os }})
-    needs: build-bundle
+      - name: Upload release metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-metadata
+          path: |
+            .release/bump-output.txt
+            .release/previous-url.txt
+            .release/release-bundles.json
+            .release/test-matrix.json
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload release docs
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-docs
+          path: |
+            www
+            dist/roc-random-docs-${{ steps.validate.outputs.docs_version }}.tar.gz
+          if-no-files-found: error
+          retention-days: 7
+
+  test-bundles:
+    name: Test ${{ matrix.bundle_name }} bundle (${{ matrix.os }})
+    needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-24.04
-          - macos-15-intel
-          - windows-2025
-    defaults:
-      run:
-        shell: bash
+        include: ${{ fromJson(needs.build.outputs.test_matrix) }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Install Zig
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # 2.2.1
-        with:
-          version: ${{ env.ZIG_VERSION }}
-          use-cache: false
 
       - name: Install Roc
         uses: roc-lang/setup-roc@bd311e2fb815a3d2255f7ee14a922f0b736e020b
         with:
           version: nightly-new-compiler
 
-      - name: Download package bundle artifact
+      - name: Download release bundles
         uses: actions/download-artifact@v4
         with:
-          name: package-bundle
-          path: dist
+          name: release-bundles
+          path: .release/test-bundles
 
-      - name: Test examples against downloaded bundle
-        run: python3 ci/test_bundle_examples.py --bundle-path "dist/${{ needs.build-bundle.outputs.bundle_filename }}"
+      - name: Test release bundle
+        uses: roc-lang/release-package/actions/test-bundle@bb018c8c96b439b9545db6c792adc0549cf01ee1
+        with:
+          test_bundle_command: python3 ci/test_bundle_examples.py --bundle-path
+          bundle_path: .release/test-bundles/${{ matrix.artifact_file }}
+          bundle_name: ${{ matrix.bundle_name }}
+          release_version: ${{ needs.build.outputs.release_version }}
 
-  create-release:
-    name: Create GitHub release
+  publish-release:
+    name: Publish GitHub release
     needs:
-      - build-bundle
-      - test-bundle
-    runs-on: ubuntu-24.04
+      - build
+      - test-bundles
     if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
     permissions:
       contents: write
-    defaults:
-      run:
-        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download release bundles
+        uses: actions/download-artifact@v4
+        with:
+          name: release-bundles
+          path: .release/bundles
+
+      - name: Download release metadata
+        uses: actions/download-artifact@v4
+        with:
+          name: release-metadata
+          path: .release
+
+      - name: Download release docs
+        uses: actions/download-artifact@v4
+        with:
+          name: release-docs
+
+      - name: Make release notes
+        uses: roc-lang/release-package/actions/make-release-notes@bb018c8c96b439b9545db6c792adc0549cf01ee1
+        with:
+          release_version: ${{ needs.build.outputs.release_version }}
+          docs_url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ needs.build.outputs.docs_version }}/
+          github_token: ${{ github.token }}
+
+      - name: Publish release
+        uses: roc-lang/release-package/actions/publish-release@bb018c8c96b439b9545db6c792adc0549cf01ee1
+        with:
+          release_version: ${{ needs.build.outputs.release_version }}
+          additional_assets: dist/roc-random-docs-${{ needs.build.outputs.docs_version }}.tar.gz
+          github_token: ${{ github.token }}
+
+  publish-docs:
+    name: Publish versioned docs
+    needs:
+      - build
+      - publish-release
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Download package bundle artifact
+      - name: Download release docs
         uses: actions/download-artifact@v4
         with:
-          name: package-bundle
-          path: dist
+          name: release-docs
 
-      - name: Install Roc
-        uses: roc-lang/setup-roc@bd311e2fb815a3d2255f7ee14a922f0b736e020b
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          version: nightly-new-compiler
+          path: www
 
-      - name: Create release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          BUNDLE_FILE="dist/${{ needs.build-bundle.outputs.bundle_filename }}"
-          ROC_VERSION=$(roc version)
+      - name: Deploy Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
 
-          gh release create "${{ github.event.inputs.release_tag }}" \
-            "$BUNDLE_FILE" \
-            --title "${{ github.event.inputs.release_tag }}" \
-            --generate-notes \
-            --notes "Random package bundle built with Roc $ROC_VERSION."
+      - name: Open docs follow-up PR
+        uses: roc-lang/release-package/actions/create-followup-pr@bb018c8c96b439b9545db6c792adc0549cf01ee1
+        with:
+          release_version: ${{ needs.build.outputs.release_version }}
+          paths: www
+          branch_prefix: release-followup
+          base_branch: ${{ github.ref_name }}
+          commit_message: Update docs for ${{ needs.build.outputs.release_version }}
+          pr_title: Update docs for ${{ needs.build.outputs.release_version }}
+          pr_body: |
+            Release follow-up for ${{ needs.build.outputs.release_version }}.
+
+            Updated generated package docs and the docs index.
+          github_token: ${{ github.token }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,24 +2,15 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  ZIG_VERSION: "0.16.0"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   test-examples:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install Zig
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # 2.2.1
-        with:
-          version: ${{ env.ZIG_VERSION }}
-          use-cache: false
 
       - name: Install Roc
         uses: roc-lang/setup-roc@bd311e2fb815a3d2255f7ee14a922f0b736e020b

--- a/ci/all_tests.sh
+++ b/ci/all_tests.sh
@@ -32,20 +32,8 @@ echo "Checking package..."
 "$ROC_BIN" check package/main.roc
 
 echo ""
-echo "Checking examples..."
-for roc_file in examples/*.roc; do
-    "$ROC_BIN" check "$roc_file"
-done
-
-echo ""
 echo "Running package tests..."
 "$ROC_BIN" test package/main.roc
-
-echo ""
-echo "Running example tests..."
-for roc_file in examples/*.roc; do
-    "$ROC_BIN" test "$roc_file"
-done
 
 echo ""
 echo "Generating package docs..."

--- a/scripts/update_example_urls.py
+++ b/scripts/update_example_urls.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_DEPENDENCY_RE = re.compile(r'(?m)^(\s*rand:\s*)"[^"]+"')
+
+
+def update_examples(examples_dir: Path, bundle_url: str) -> list[Path]:
+    examples = sorted(examples_dir.glob("*.roc"))
+    if not examples:
+        raise SystemExit(f"No Roc examples found in {examples_dir}")
+
+    updated: list[Path] = []
+    for example in examples:
+        source = example.read_text(encoding="utf-8")
+        rewritten, count = PACKAGE_DEPENDENCY_RE.subn(
+            lambda match: f'{match.group(1)}"{bundle_url}"',
+            source,
+            count=1,
+        )
+        if count != 1:
+            raise SystemExit(f"{example} does not declare the expected rand package dependency")
+        if rewritten != source:
+            example.write_text(rewritten, encoding="utf-8")
+            updated.append(example)
+
+    return updated
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bundle-url", required=True)
+    parser.add_argument("--examples-dir", type=Path, default=ROOT / "examples")
+    args = parser.parse_args()
+
+    updated = update_examples(args.examples_dir, args.bundle_url)
+    if updated:
+        print("Updated example URLs:")
+        for path in updated:
+            print(f"- {display_path(path)}")
+    else:
+        print("Example URLs are already up to date.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- replace the hand-written release jobs with the composite actions from roc-lang/release-package, pinned to bb018c8c96b439b9545db6c792adc0549cf01ee1
- validate release requests, package behavior, required Roc version bumps, produced bundles, release notes, publication, and versioned docs
- validate the pure package bundle on ubuntu-latest and remove unnecessary Zig setup from release and test workflows
- generate and validate the complete docs site once, upload it as an Actions artifact, attach roc-random-docs-VERSION.tar.gz to the GitHub release, and deploy it to Pages
- derive the newly published package URL from .release/release-bundles.json, validate updated examples, and open a follow-up PR containing both examples and docs

## Shared action refs

All release-package actions use immutable commit bb018c8c96b439b9545db6c792adc0549cf01ee1:

- validate-release
- resolve-previous-release
- run-bump-check with bump_check: require
- prepare-bundles and test-bundle
- make-release-notes and publish-release
- docs-snapshot, docs-index, and docs-validate
- create-followup-pr

Roc setup remains pinned to bd311e2fb815a3d2255f7ee14a922f0b736e020b with version nightly-new-compiler.

## Verification

- ./ci/all_tests.sh — passed package validation, docs generation, bundle creation, and every example check/test/run/build against the generated localhost bundle
- roc bump against the published 0.6.0 bundle with --expect 0.6.1 — passed; no API changes and PATCH required
- scripts/update_example_urls.py — passed rewrite and idempotence checks across all eight examples
- roc fmt --check package examples — passed
- actionlint 1.7.12 — passed
- shared docs helpers — preserved historical 0.5.0 and 0.6.0 docs, generated and indexed 0.6.1, and passed docs validation
- docs tar archive inspection — passed; archive contains the complete versioned www site
- bash syntax checks, Python bytecode compilation, and git diff --check — passed

## Repository-specific decisions

- roc-random is a pure package, so bundle validation uses only ubuntu-latest; its examples use a released platform with a prebuilt host.
- CI no longer checks checked-in example package URLs before bundling. It always rewrites temporary copies to the freshly produced localhost bundle, then checks, tests, runs, builds, and executes all examples.
- The checked-in ../package/main.roc references remain temporarily because current main contains post-0.6.0 behavior and its expectations do not pass against the stale 0.6.0 release. After the next release, the follow-up PR rewrites every example to the newly published asset URL and validates those sources before committing them.
- Docs deploy immediately from the validated Actions artifact. The follow-up PR records both examples and www on the release branch; the existing manual Pages workflow remains available as a fallback.
- The repository must allow GitHub Actions to create pull requests for create-followup-pr to work with GITHUB_TOKEN.

## Intentional deviations

- scripts/bundle.sh was not changed because it already bundles package/main.roc plus every other package/*.roc file into the requested output directory.
- No multi-OS bundle matrix or Zig installation is retained because neither is meaningful for this pure package and prebuilt example platform.