### PR TITLE
Upgrade Roc nightly to 2026-08-12-606470f

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -31,49 +15,6 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "nixgl": {
-      "inputs": {
-        "flake-utils": [
-          "roc",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "roc",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1713543440,
-        "narHash": "sha256-lnzZQYG0+EXl/6NkGpyIz+FEOc/DSEG57AP1VsdeNrM=",
-        "owner": "guibou",
-        "repo": "nixGL",
-        "rev": "310f8e49a149e4c9ea52f1adf70cdc768ec53f8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "guibou",
-        "repo": "nixGL",
         "type": "github"
       }
     },
@@ -105,86 +46,10 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1722403750,
-        "narHash": "sha256-tRmn6UiFAPX0m9G1AVcEPjWEOc9BtGsxGcs7Bz3MpsM=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "184957277e885c06a505db112b35dfbec7c60494",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "184957277e885c06a505db112b35dfbec7c60494",
-        "type": "github"
-      }
-    },
-    "roc": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
-        "nixgl": "nixgl",
-        "nixpkgs": "nixpkgs_2",
-        "rust-overlay": "rust-overlay"
-      },
-      "locked": {
-        "lastModified": 1738131757,
-        "narHash": "sha256-cXWFnT2SlNvc8gRAhlUNakVGWii3VWZsvNijMRpX7XA=",
-        "owner": "roc-lang",
-        "repo": "roc",
-        "rev": "689c58f35e0a39ca59feba549f7fcf375562a7a6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "roc-lang",
-        "ref": "0.0.0-alpha2-rolling",
-        "repo": "roc",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
-        "roc": "roc"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "roc",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1736303309,
-        "narHash": "sha256-IKrk7RL+Q/2NC6+Ql6dwwCNZI6T6JH2grTdJaVWHF0A=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "a0b81d4fa349d9af1765b0f0b4a899c13776f706",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,12 +2,6 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
-    roc.url = "github:roc-lang/roc/0.0.0-alpha2-rolling";
-  };
-
-  nixConfig = {
-    extra-trusted-public-keys = "roc-lang.cachix.org-1:6lZeqLP9SadjmUbskJAvcdGR2T5ViR57pDVkxJQb8R4=";
-    extra-trusted-substituters = "https://roc-lang.cachix.org";
   };
 
   outputs =
@@ -21,15 +15,55 @@
       ];
       perSystem =
         {
-          inputs',
           pkgs,
           ...
         }:
+        let
+          nightly = {
+            x86_64-linux = {
+              archive = "roc_nightly-linux_x86_64-2026-08-12-606470f.tar.gz";
+              hash = "sha256-+6w4OMzn6UaviQz6/kiZTJhTyZYt3mOy+YgNCky39+4=";
+              directory = "roc_nightly-linux_x86_64-2026-08-12-606470f";
+            };
+            aarch64-linux = {
+              archive = "roc_nightly-linux_arm64-2026-08-12-606470f.tar.gz";
+              hash = "sha256-Y9b0N8xhvyyisBYD6T25BXz2pkCt7+jT0zff6k4maEg=";
+              directory = "roc_nightly-linux_arm64-2026-08-12-606470f";
+            };
+            x86_64-darwin = {
+              archive = "roc_nightly-macos_x86_64-2026-08-12-606470f.tar.gz";
+              hash = "sha256-gcf0MtDX8wxt1G7RvcNhSXB11MvYBJZU4kSyh+r6nQk=";
+              directory = "roc_nightly-macos_x86_64-2026-08-12-606470f";
+            };
+            aarch64-darwin = {
+              archive = "roc_nightly-macos_apple_silicon-2026-08-12-606470f.tar.gz";
+              hash = "sha256-MOthF4SSC1NTW9S3rNgp/oX1Tyq6frDwTL8yeK0CFnk=";
+              directory = "roc_nightly-macos_apple_silicon-2026-08-12-606470f";
+            };
+          }.${pkgs.stdenv.hostPlatform.system};
+
+          roc-nightly = pkgs.stdenvNoCC.mkDerivation {
+            pname = "roc-nightly";
+            version = "2026-08-12-606470f";
+            src = pkgs.fetchurl {
+              url = "https://github.com/roc-lang/nightlies/releases/download/nightly-2026-08-12-606470f/${nightly.archive}";
+              inherit (nightly) hash;
+            };
+            dontBuild = true;
+            unpackPhase = "tar -xzf $src";
+            sourceRoot = ".";
+            installPhase = ''
+              mkdir -p $out/bin $out/lib
+              install -m755 ${nightly.directory}/roc $out/bin/roc
+              cp -R ${nightly.directory}/lib/. $out/lib/
+            '';
+          };
+        in
         {
           devShells.default = pkgs.mkShell {
             name = "roc-random";
             packages = [
-              inputs'.roc.packages.cli
+              roc-nightly
               pkgs.actionlint
               pkgs.nixfmt-rfc-style
               pkgs.nodePackages.prettier


### PR DESCRIPTION
## Summary
- install Roc from the published `nightly-2026-08-12-606470f` release archives
- pin each supported platform archive with its SHA-256 checksum
- remove the obsolete alpha2 rolling flake input and its Cachix configuration

## Verification
- `ROC=<published nightly binary> ci/all_tests.sh`
  - formatting and package checks passed
  - 57 package tests passed
  - docs and bundle generation passed
  - all bundled examples checked, tested, built, and ran successfully