### PR TITLE
Fix (0..<32).rev() and weird type issue

### DIFF
--- a/examples/color.roc
+++ b/examples/color.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-	rand: "https://github.com/kili-ilo/roc-random/releases/download/0.9.0/CwDEAmyUMCsqW6dh4pxYnp7suUZAj5b5gpZuh7udtyE7.tar.zst",
+	rand: "../package/main.roc",
 }
 
 import pf.Stdout

--- a/examples/dice.roc
+++ b/examples/dice.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-	rand: "https://github.com/kili-ilo/roc-random/releases/download/0.9.0/CwDEAmyUMCsqW6dh4pxYnp7suUZAj5b5gpZuh7udtyE7.tar.zst",
+	rand: "../package/main.roc",
 }
 
 import pf.Stdout

--- a/examples/encounter.roc
+++ b/examples/encounter.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-	rand: "https://github.com/kili-ilo/roc-random/releases/download/0.9.0/CwDEAmyUMCsqW6dh4pxYnp7suUZAj5b5gpZuh7udtyE7.tar.zst",
+	rand: "../package/main.roc",
 }
 
 import pf.Stdout

--- a/examples/numbers.roc
+++ b/examples/numbers.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-	rand: "https://github.com/kili-ilo/roc-random/releases/download/0.9.0/CwDEAmyUMCsqW6dh4pxYnp7suUZAj5b5gpZuh7udtyE7.tar.zst",
+	rand: "../package/main.roc",
 }
 
 import pf.Stdout

--- a/examples/record-builder.roc
+++ b/examples/record-builder.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-	rand: "https://github.com/kili-ilo/roc-random/releases/download/0.9.0/CwDEAmyUMCsqW6dh4pxYnp7suUZAj5b5gpZuh7udtyE7.tar.zst",
+	rand: "../package/main.roc",
 }
 
 import pf.Stdout

--- a/examples/simple.roc
+++ b/examples/simple.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-	rand: "https://github.com/kili-ilo/roc-random/releases/download/0.9.0/CwDEAmyUMCsqW6dh4pxYnp7suUZAj5b5gpZuh7udtyE7.tar.zst",
+	rand: "../package/main.roc",
 }
 
 import pf.Stdout

--- a/examples/state-threading.roc
+++ b/examples/state-threading.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-	rand: "https://github.com/kili-ilo/roc-random/releases/download/0.9.0/CwDEAmyUMCsqW6dh4pxYnp7suUZAj5b5gpZuh7udtyE7.tar.zst",
+	rand: "../package/main.roc",
 }
 
 import pf.Stdout

--- a/examples/variants.roc
+++ b/examples/variants.roc
@@ -1,6 +1,6 @@
 app [main!] {
 	pf: platform "https://github.com/lukewilliamboswell/roc-platform-template-zig/releases/download/0.9/8GdFEvQYS3TeAZxKvTzCLVdQiomweGtXcdZkXNDEeABq.tar.zst",
-	rand: "https://github.com/kili-ilo/roc-random/releases/download/0.9.0/CwDEAmyUMCsqW6dh4pxYnp7suUZAj5b5gpZuh7udtyE7.tar.zst",
+	rand: "../package/main.roc",
 }
 
 import pf.Stdout

--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -31,49 +15,6 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "nixgl": {
-      "inputs": {
-        "flake-utils": [
-          "roc",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "roc",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1713543440,
-        "narHash": "sha256-lnzZQYG0+EXl/6NkGpyIz+FEOc/DSEG57AP1VsdeNrM=",
-        "owner": "guibou",
-        "repo": "nixGL",
-        "rev": "310f8e49a149e4c9ea52f1adf70cdc768ec53f8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "guibou",
-        "repo": "nixGL",
         "type": "github"
       }
     },
@@ -105,86 +46,10 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1722403750,
-        "narHash": "sha256-tRmn6UiFAPX0m9G1AVcEPjWEOc9BtGsxGcs7Bz3MpsM=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "184957277e885c06a505db112b35dfbec7c60494",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "184957277e885c06a505db112b35dfbec7c60494",
-        "type": "github"
-      }
-    },
-    "roc": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
-        "nixgl": "nixgl",
-        "nixpkgs": "nixpkgs_2",
-        "rust-overlay": "rust-overlay"
-      },
-      "locked": {
-        "lastModified": 1738131757,
-        "narHash": "sha256-cXWFnT2SlNvc8gRAhlUNakVGWii3VWZsvNijMRpX7XA=",
-        "owner": "roc-lang",
-        "repo": "roc",
-        "rev": "689c58f35e0a39ca59feba549f7fcf375562a7a6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "roc-lang",
-        "ref": "0.0.0-alpha2-rolling",
-        "repo": "roc",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
-        "roc": "roc"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "roc",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1736303309,
-        "narHash": "sha256-IKrk7RL+Q/2NC6+Ql6dwwCNZI6T6JH2grTdJaVWHF0A=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "a0b81d4fa349d9af1765b0f0b4a899c13776f706",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,12 +2,6 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
-    roc.url = "github:roc-lang/roc/0.0.0-alpha2-rolling";
-  };
-
-  nixConfig = {
-    extra-trusted-public-keys = "roc-lang.cachix.org-1:6lZeqLP9SadjmUbskJAvcdGR2T5ViR57pDVkxJQb8R4=";
-    extra-trusted-substituters = "https://roc-lang.cachix.org";
   };
 
   outputs =
@@ -21,15 +15,55 @@
       ];
       perSystem =
         {
-          inputs',
           pkgs,
           ...
         }:
+        let
+          nightly = {
+            x86_64-linux = {
+              archive = "roc_nightly-linux_x86_64-2026-08-13-2fdd90e.tar.gz";
+              hash = "sha256-ODVmIwVdLpuhACHALiIe4gA/mmsua5u9/t+j53lPoPk=";
+              directory = "roc_nightly-linux_x86_64-2026-08-13-2fdd90e";
+            };
+            aarch64-linux = {
+              archive = "roc_nightly-linux_arm64-2026-08-13-2fdd90e.tar.gz";
+              hash = "sha256-2toZcyf+LbF+awsDRY5yfmgIQqFPY3alLUcf3Dux6yM=";
+              directory = "roc_nightly-linux_arm64-2026-08-13-2fdd90e";
+            };
+            x86_64-darwin = {
+              archive = "roc_nightly-macos_x86_64-2026-08-13-2fdd90e.tar.gz";
+              hash = "sha256-B62/lz4bmLRTX00ITpqrmV+x5tT0xaHlDuKAzcKGBqg=";
+              directory = "roc_nightly-macos_x86_64-2026-08-13-2fdd90e";
+            };
+            aarch64-darwin = {
+              archive = "roc_nightly-macos_apple_silicon-2026-08-13-2fdd90e.tar.gz";
+              hash = "sha256-4Fd6esLFj4nLKd0gxu4d9CXFBobH41S0yvDi3pklm1o=";
+              directory = "roc_nightly-macos_apple_silicon-2026-08-13-2fdd90e";
+            };
+          }.${pkgs.stdenv.hostPlatform.system};
+
+          roc-nightly = pkgs.stdenvNoCC.mkDerivation {
+            pname = "roc-nightly";
+            version = "2026-08-13-2fdd90e";
+            src = pkgs.fetchurl {
+              url = "https://github.com/roc-lang/nightlies/releases/download/nightly-2026-08-13-2fdd90e/${nightly.archive}";
+              inherit (nightly) hash;
+            };
+            dontBuild = true;
+            unpackPhase = "tar -xzf $src";
+            sourceRoot = ".";
+            installPhase = ''
+              mkdir -p $out/bin $out/lib
+              install -m755 ${nightly.directory}/roc $out/bin/roc
+              cp -R ${nightly.directory}/lib/. $out/lib/
+            '';
+          };
+        in
         {
           devShells.default = pkgs.mkShell {
             name = "roc-random";
             packages = [
-              inputs'.roc.packages.cli
+              roc-nightly
               pkgs.actionlint
               pkgs.nixfmt-rfc-style
               pkgs.nodePackages.prettier

--- a/package/Random.roc
+++ b/package/Random.roc
@@ -194,7 +194,7 @@ Random := [].{
 			if items.len() < 2 return { value: items, state: $state }
 
 			var $items = items
-			for i in (1..<items.len()).rev() {
+			for i in List.from_iter(1..<items.len()).rev() {
 				{ value: choice_i, state: $state } =
 					bounded_u64(0, i)($state)
 				$items = match $items.swap(i, choice_i) {
@@ -275,6 +275,7 @@ Random := [].{
 	## A `Generator` for the full range of 64-bit unsigned integers
 	u64 : Generator(U64)
 	u64 = {
+		component_generator : Generator({ hi : U32, lo : U32 })
 		component_generator = {
 			hi: u32,
 			lo: u32,
@@ -284,8 +285,7 @@ Random := [].{
 			|> map(
 				|{ hi, lo }| {
 					hi_shifted = hi.to_u64().shl_wrap(32)
-
-					(hi_shifted).bitwise_or(lo.to_u64())
+					hi_shifted.bitwise_or(lo.to_u64())
 				},
 			)
 	}
@@ -995,16 +995,21 @@ pcg_c_known_answer_test_generator : Generator(Str)
 pcg_c_known_answer_test_generator = |state| {
 	u32_to_hex_str : U32 -> Str
 	u32_to_hex_str = |n| {
-		digits = (0..<32).step_by(4).rev().map(
-			|shift| {
-				nibble = n.shr_zf_wrap(shift).bitwise_and(0xF).to_u8_wrap()
-				if nibble < 10 {
-					nibble + '0'
-				} else {
-					(nibble - 10) + 'a'
-				}
-			},
-		).collect()
+		digits =
+			(0..<32)
+				.step_by(4)
+				|> List.from_iter
+				.rev()
+				.map(
+					|shift| {
+						nibble = n.shr_zf_wrap(shift).bitwise_and(0xF).to_u8_wrap()
+						if nibble < 10 {
+							nibble + '0'
+						} else {
+							(nibble - 10) + 'a'
+						}
+					},
+				)
 		"0x${Str.from_utf8_lossy(digits)}"
 	}
 
@@ -1085,7 +1090,7 @@ shuffle_with_u32 = |items| {
 		if items.len() < 2 return { value: items, state: $state }
 
 		var $items = items
-		for i in (1..<items.len()).rev() {
+		for i in List.from_iter(1..<items.len()).rev() {
 			{ value: choice_i, state: $state } =
 				Random.bounded_u32(0, i.to_u32_wrap())($state)
 			$items = match $items.swap(i, choice_i.to_u64()) {


### PR DESCRIPTION
A recent [breaking change](https://roc.zulipchat.com/#narrow/channel/397893-announcements/topic/Breaking.20change.3A.20removing.20Iter.2Erev.20and.20Iter.2Etake_last/with/615312907) broke `roc-random`: `(0..<32).rev()` no longer works.

This PR fixes that by converting the range to a `List`.
I also replaced `rand: "https:..."` with `rand: "../package/main.roc"` to run all the examples, they work fine now. Of course these should be changed to the next release URL, to make it easier for new users to try out these examples.

Note: I also had to add a type spec on line 278 or else the code would break. Quite odd.