### PR TITLE
Wrap on overflow when applying the initial seed (#66)

### DIFF
--- a/package/Random.roc
+++ b/package/Random.roc
@@ -102,7 +102,9 @@ Random := [].{
 
 		var $seed = State.({ s: 0, update_increment })
 		$seed = $seed |> update
-		$seed = { ..$seed, s: $seed.s + initial_seed }
+		# Wrap on overflow like the rest of the PCG arithmetic; a plain `+` here
+		# panicked for large seeds (e.g. `U32.highest`). (#66)
+		$seed = { ..$seed, s: add_wrap_u32($seed.s, initial_seed) }
 		$seed |> update
 	}
 
@@ -781,6 +783,15 @@ expect {
 			rand_generation.value == 5
 		},
 	)
+}
+
+# Regression test for #66: seeding with a large value used to panic with an
+# integer addition overflow inside `seed_variant`.
+expect {
+	this_seed = Random.seed(U32.highest)
+	rand_generation = Random.step(this_seed, Random.static(5))
+
+	rand_generation.value == 5
 }
 
 expect {


### PR DESCRIPTION
Fixes #66.

### Problem

`seed_variant` applies the initial seed with a plain `+`:

```roc
$seed = { ..$seed, s: $seed.s + initial_seed }
```

On `U32`, `+` panics on overflow, so seeding with a large value crashes:

```
$ seed(U32.highest)
Roc application crashed with this message:
	Integer addition overflowed
```

`seed` is the primary public constructor, so this is reachable from normal use. Every other step of the PCG arithmetic in this file already uses the wrapping helpers (`add_wrap_u32` / `mul_wrap_u32`), and the reference PCG seeding wraps as well; this one `+` was an oversight.

### Fix

Use `add_wrap_u32`, matching the rest of the file:

```roc
$seed = { ..$seed, s: add_wrap_u32($seed.s, initial_seed) }
```

### Test

Added a regression `expect` that seeds with `U32.highest` and steps the generator. Red-green verified with `roc test package/main.roc` (nightly `nightly-2026-08-13`): before the change the run crashes with `Integer addition overflowed` (57 passed, 1 failed); after, all 58 tests pass. `roc fmt --check package` is clean.

---
Disclosure: I used AI assistance (Claude) while preparing this change. I reproduced the overflow, ran the tests (red-green), and take responsibility for the contribution.
